### PR TITLE
Fix typos in comments

### DIFF
--- a/core/haxlib.vcxproj
+++ b/core/haxlib.vcxproj
@@ -258,7 +258,7 @@
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
     <FilesToPackage Include="$(DDK_PACKAGE_FILES)" />
   </ItemGroup>
-  <!-- Necessary to pick up propper files from local directory when in the IDE-->
+  <!-- Necessary to pick up proper files from local directory when in the IDE-->
   <ItemGroup>
     <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
     <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
@@ -267,6 +267,6 @@
   <ItemGroup>
     <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
   </ItemGroup>
-  <!-- /Necessary to pick up propper files from local directory when in the IDE-->
+  <!-- /Necessary to pick up proper files from local directory when in the IDE-->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/core/include/hax_core_interface.h
+++ b/core/include/hax_core_interface.h
@@ -71,7 +71,7 @@ int vcpu_execute(struct vcpu_t *vcpu);
 int vcpu_interrupt(struct vcpu_t *vcpu, uint8 vector);
 
 /*
- * Find a vcpu with correponding id, |refer| decides whether a reference count
+ * Find a vcpu with corresponding id, |refer| decides whether a reference count
  * is added
  */
 struct vcpu_t * hax_get_vcpu(int vm_id, int vcpu_id, int refer);

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -39,7 +39,7 @@
 #define IA32_VMX_VMCS_SIZE 4096
 
 enum {
-    INT_EXCEPTION_NMI       = 0, // An SW interrupt, excepton or NMI has occured
+    INT_EXCEPTION_NMI       = 0, // An SW interrupt, exception or NMI has occurred
     EXT_INTERRUPT           = 1, // An external interrupt has occurred
     TRIPLE_FAULT            = 2, // Triple fault occurred
     INIT_EVENT              = 3,

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -485,7 +485,7 @@ fail_0:
 }
 
 /*
- * We don't need correponding vcpu_core_close because once closed, the VM will
+ * We don't need corresponding vcpu_core_close because once closed, the VM will
  * be destroyed
  */
 int hax_vcpu_core_open(struct vcpu_t *vcpu)
@@ -4356,7 +4356,7 @@ int vcpu_takeoff(struct vcpu_t *vcpu)
         cpu_id = vcpu->cpu_id;
         assert(cpu_id != hax_cpuid());
         targets = cpu2cpumap(cpu_id);
-        // If not considering Windows XP, definitly we don't need this
+        // If not considering Windows XP, definitely we don't need this
         smp_call_function(&targets, _vcpu_take_off, NULL);
     }
 

--- a/core/vm.c
+++ b/core/vm.c
@@ -209,7 +209,7 @@ static void hax_vm_free_p2m_map(struct vm_t *vm)
 }
 
 /*
- * We don't need correponding vm_core_close because once closed, the VM will be
+ * We don't need corresponding vm_core_close because once closed, the VM will be
  * destroyed.
  */
 int hax_vm_core_open(struct vm_t *vm)

--- a/include/darwin/hax_interface_mac.h
+++ b/include/darwin/hax_interface_mac.h
@@ -33,7 +33,7 @@
 
 #include <mach/mach_types.h>
 
-/* The mac specfic interface to qemu because of mac's
+/* The mac specific interface to qemu because of mac's
  * special handling like hax tunnel allocation etc */
 /* HAX model level ioctl */
 #define HAX_IOCTL_VERSION _IOWR(0, 0x20, struct hax_module_version)

--- a/include/darwin/hax_types_mac.h
+++ b/include/darwin/hax_types_mac.h
@@ -52,7 +52,7 @@ typedef uint32_t hax_size_t;
 typedef uint64_t hax_va_t;
 typedef uint32_t hax_size_t;
 
-/* Spinlock releated defintion */
+/* Spinlock releated definition */
 typedef lck_spin_t hax_spinlock;
 typedef lck_mtx_t* hax_mutex;
 typedef lck_rw_t hax_rw_lock;

--- a/include/hax.h
+++ b/include/hax.h
@@ -69,7 +69,7 @@ extern int hax_page_size;
 /* below 4G */
 // !!!! This will only for hax_page allocation to simplify handling
 #define HAX_MEM_LOW_4G  0x4
-/* The allocated memory will be physically continous */
+/* The allocated memory will be physically continuous */
 // !!!! Since no one use this flag, remove it
 //#define HAX_MEM_CONTI  0x8
 /* The allocation will not be blocked, thus works for interrupt handling */
@@ -110,7 +110,7 @@ void hax_vfree_flags(void *va, uint32_t size, uint32_t flags);
  * Allocate aligned memory, which is mapped in kernel space already
  * For example, 256 get memory allocated at an address with bit 0-7 set 0
  * With (flags&HAX_MEM_CONTI) && alignment==PAGE_SIZE, it can allocate
- * continous physical memory
+ * continuous physical memory
  */
 void *hax_vmalloc_aligned(uint32_t size, uint32_t flags, uint32_t alignment);
 

--- a/windows/IntelHaxm.vcxproj
+++ b/windows/IntelHaxm.vcxproj
@@ -293,7 +293,7 @@
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
     <FilesToPackage Include="$(DDK_PACKAGE_FILES)" />
   </ItemGroup>
-  <!-- Necessary to pick up propper files from local directory when in the IDE-->
+  <!-- Necessary to pick up proper files from local directory when in the IDE-->
   <ItemGroup>
     <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
     <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
@@ -302,7 +302,7 @@
   <ItemGroup>
     <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
   </ItemGroup>
-  <!-- /Necessary to pick up propper files from local directory when in the IDE-->
+  <!-- /Necessary to pick up proper files from local directory when in the IDE-->
   <ItemGroup>
     <ProjectReference Include="..\core\haxlib.vcxproj">
       <Project>{BC80D1E0-5738-4048-A742-8A20949A6587}</Project>


### PR DESCRIPTION
Most of them were found by Codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>