### PR TITLE
Revert RAM block refcount

### DIFF
--- a/core/include/memory.h
+++ b/core/include/memory.h
@@ -53,10 +53,9 @@ typedef struct hax_ramblock {
     // One bit per chunk indicating whether the chunk has been (or is being)
     // allocated/pinned or not
     uint8 *chunks_bitmap;
-    // Reference count of this object
-    int ref_count;
     // Turns this object into a list node
     hax_list_node entry;
+    // TODO: refcount?
 } hax_ramblock;
 
 typedef struct hax_memslot {
@@ -81,8 +80,6 @@ typedef struct hax_memslot {
 #define HAX_MEMSLOT_INVALID  0x80
 
 typedef struct hax_gpa_space {
-    // TODO: Add a lock to prevent concurrent accesses to |ramblock_list| and
-    // |memslot_list|
     hax_list_head ramblock_list;
     hax_list_head memslot_list;
     hax_list_head listener_list;
@@ -165,20 +162,6 @@ int ramblock_add(hax_list_head *list, uint64 base_uva, uint64 size,
 //    was not successful.
 hax_chunk * ramblock_get_chunk(hax_ramblock *block, uint64 uva_offset,
                                bool alloc);
-
-// Increments the reference count of an existing RAM block. The reference count
-// of a new RAM block created by ramblock_add() is initialized to 0. Whenever a
-// new reference to a RAM block is made, this function must be called.
-// |block|: A pointer to |hax_ramblock| being referenced.
-void ramblock_ref(hax_ramblock *block);
-
-// Decrements the reference count of the specified RAM block. Whenever a
-// reference to a RAM block is removed, this function must be called. If the
-// resulting reference count hits zero, removes the RAM block from the list it
-// belongs to, and frees the RAM block along with all the resources allocated
-// for it.
-// |block|: A pointer to |hax_ramblock| being dereferenced.
-void ramblock_deref(hax_ramblock *block);
 
 // Initializes |hax_memslot|-related data structures in the given
 // |hax_gpa_space|.

--- a/core/memslot.c
+++ b/core/memslot.c
@@ -35,7 +35,7 @@
 #define MEMSLOT_PROCESSING 0x01
 #define MEMSLOT_TO_INSERT  0x02
 
-#define MEMSLOT_DUP(m) if (((m) = memslot_dup(m)) == NULL) return -ENOMEM
+#define MEMSLOT_ALLOC(m) if (((m) = memslot_alloc(m)) == NULL) return -ENOMEM
 #define SAFE_CALL(f) if ((f) != NULL) (f)
 
 enum callback {
@@ -62,13 +62,13 @@ typedef struct memslot_mapping {
     uint8 new_flags;
 } memslot_mapping;
 
-static void memslot_init(hax_memslot *dest, hax_memslot *src);
-static hax_memslot * memslot_dup(hax_memslot *slot);
+static hax_memslot * memslot_alloc(hax_memslot *dest);
+static void memslot_free(void **memslot, uint32 size);
+static void memslot_copy(hax_memslot *dest, hax_memslot *src);
 static void memslot_insert_before(hax_memslot *dest, hax_memslot *src);
 static void memslot_insert_after(hax_memslot *dest, hax_memslot *src);
 static void memslot_insert_head(hax_memslot *dest, hax_gpa_space *gpa_space);
 static void memslot_delete(hax_memslot *dest);
-static void memslot_move(hax_memslot *dest, hax_memslot *src);
 static void memslot_union(hax_memslot *dest, hax_memslot *src);
 static void memslot_overlap_front(hax_memslot *dest, hax_memslot *src);
 static void memslot_overlap_rear(hax_memslot *dest, hax_memslot *src);
@@ -96,7 +96,7 @@ static void mapping_calc_change(memslot_mapping *mapping, hax_memslot *src,
                                 bool is_valid, bool is_terminal,
                                 bool is_changed, memslot_mapping *hole,
                                 memslot_mapping *slot);
-static int mapping_enqueue(hax_list_head *memslot_list, hax_memslot *dest);
+static void mapping_enqueue(hax_list_head *memslot_list, hax_memslot *dest);
 static void mapping_intersect(memslot_mapping *dest, memslot_mapping *src);
 static bool mapping_is_changed(hax_memslot *dest, hax_memslot *src,
                                bool is_valid, bool is_terminal);
@@ -147,7 +147,7 @@ void memslot_dump_list(hax_gpa_space *gpa_space)
     hax_info("memslot dump begins:\n");
     hax_list_entry_for_each(memslot, &gpa_space->memslot_list, hax_memslot,
                             entry) {
-        hax_info("memslot [%d]: base_gfn = 0x%016llx, npages = 0x%llx, "
+        hax_info("memory slot [%d]: base_gfn = 0x%016llx, npages = 0x%llx, "
                  "uva = 0x%016llx, flags = 0x%02x "
                  "(block_base_uva = 0x%016llx, offset_within_block = 0x%llx)\n",
                  i++, memslot->base_gfn, memslot->npages,
@@ -200,13 +200,13 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
 
     if (hax_list_empty(&gpa_space->memslot_list)) {
         if (is_valid) {
-            MEMSLOT_DUP(dest);
+            MEMSLOT_ALLOC(dest);
             memslot_insert_head(dest, gpa_space);
 
             mapping_broadcast(&gpa_space->listener_list, &mapping, dest, NULL);
         }
 
-        goto out;
+        return 0;
     }
 
     hax_init_list_head(&memslot_list);
@@ -219,7 +219,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                     continue;
 
                 if (is_valid) {
-                    MEMSLOT_DUP(dest);
+                    MEMSLOT_ALLOC(dest);
                     memslot_insert_after(dest, src);
                 }
                 break;
@@ -237,7 +237,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                     : MAPPING_INVALID;
             ret = memslot_process_start[route](dest, src, &state);
             if (ret != 0)
-                goto out;
+                return ret;
 
             is_found = true;
         } else {
@@ -257,7 +257,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                     : MAPPING_INVALID;
             ret = memslot_process_end[route](dest, src, &state);
             if (ret != 0)
-                goto out;
+                return ret;
 
             state = 0;
         }
@@ -267,23 +267,14 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
     }
 
     if (state & MEMSLOT_TO_INSERT) {
-        MEMSLOT_DUP(dest);
+        MEMSLOT_ALLOC(dest);
         memslot_insert_before(dest, src);
     }
 
     mapping_broadcast(&gpa_space->listener_list, &mapping, dest,
                       &memslot_list);
 
-out:
-    // ramblock_find() was invoked previously in this function and returned a
-    // pointer to an existing |hax_ramblock|, whose refcount was incremented by
-    // ramblock_find(). Now that the pointer (local variable |block|) is about
-    // to go out of scope, ramblock_deref() must be invoked here to keep the
-    // refcount accurate.
-    if (block != NULL) {
-        ramblock_deref(block);
-    }
-    return ret;
+    return 0;
 }
 
 hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64 gfn)
@@ -305,27 +296,41 @@ hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64 gfn)
     return NULL;
 }
 
-static void memslot_init(hax_memslot *dest, hax_memslot *src)
+static inline hax_memslot * memslot_alloc(hax_memslot *memslot)
 {
-    *dest = *src;
-    ramblock_ref(dest->block);
-    hax_init_list_head(&dest->entry);
+    hax_memslot *ptr = NULL;
+
+    ptr = (hax_memslot *)hax_vmalloc(sizeof(hax_memslot), HAX_MEM_NONPAGE);
+
+    if (ptr == NULL)
+        return NULL;
+
+    ptr->base_gfn            = memslot->base_gfn;
+    ptr->npages              = memslot->npages;
+    ptr->block               = memslot->block;
+    ptr->offset_within_block = memslot->offset_within_block;
+    ptr->flags               = memslot->flags;
+    hax_init_list_head(&ptr->entry);
+
+    return ptr;
 }
 
-static inline hax_memslot * memslot_dup(hax_memslot *slot)
+static inline void memslot_free(void **va, uint32 size)
 {
-    hax_memslot *new_slot = NULL;
+    if ((va == NULL) || (*va == NULL))
+        return;
 
-    new_slot = (hax_memslot *)hax_vmalloc(sizeof(hax_memslot), HAX_MEM_NONPAGE);
+    hax_vfree(*va, size);
+    *va = NULL;
+}
 
-    if (new_slot == NULL) {
-        hax_error("%s: Failed to allocate memslot\n", __func__);
-        return NULL;
-    }
-
-    memslot_init(new_slot, slot);
-
-    return new_slot;
+static inline void memslot_copy(hax_memslot *dest, hax_memslot *src)
+{
+    dest->base_gfn            = src->base_gfn;
+    dest->npages              = src->npages;
+    dest->block               = src->block;
+    dest->offset_within_block = src->offset_within_block;
+    dest->flags               = src->flags;
 }
 
 static inline void memslot_insert_before(hax_memslot *dest, hax_memslot *src)
@@ -347,14 +352,7 @@ static inline void memslot_insert_head(hax_memslot *dest,
 static inline void memslot_delete(hax_memslot *dest)
 {
     hax_list_del(&dest->entry);
-    ramblock_deref(dest->block);
-    hax_vfree(dest, sizeof(hax_memslot));
-}
-
-static inline void memslot_move(hax_memslot *dest, hax_memslot *src)
-{
-    ramblock_deref(dest->block);
-    memslot_init(dest, src);
+    memslot_free((void **)&dest, sizeof(hax_memslot));
 }
 
 static inline void memslot_union(hax_memslot *dest, hax_memslot *src)
@@ -383,24 +381,21 @@ static inline void memslot_overlap_rear(hax_memslot *dest, hax_memslot *src)
 static inline hax_memslot * memslot_append_rest(hax_memslot *dest,
                                                 hax_memslot *src)
 {
-    hax_memslot *rest, slot;
+    hax_memslot *rest = NULL;
 
     rest = (hax_memslot *)hax_vmalloc(sizeof(hax_memslot), HAX_MEM_NONPAGE);
 
-    if (rest == NULL) {
-        hax_error("%s: Failed to allocate memslot\n", __func__);
+    if (rest == NULL)
         return NULL;
-    }
 
-    slot.base_gfn            = dest->base_gfn + dest->npages;
-    slot.npages              = src->base_gfn + src->npages - dest->base_gfn
-                               - dest->npages;
-    slot.block               = src->block;
-    slot.offset_within_block = src->offset_within_block + ((dest->base_gfn
-                               + dest->npages - src->base_gfn) << PG_ORDER_4K);
-    slot.flags               = src->flags;
-
-    memslot_init(rest, &slot);
+    rest->base_gfn            = dest->base_gfn + dest->npages;
+    rest->npages              = src->base_gfn + src->npages - dest->base_gfn
+                                - dest->npages;
+    rest->block               = src->block;
+    rest->offset_within_block = src->offset_within_block + ((dest->base_gfn
+                                + dest->npages - src->base_gfn) << PG_ORDER_4K);
+    rest->flags               = src->flags;
+    hax_init_list_head(&rest->entry);
 
     return rest;
 }
@@ -471,13 +466,13 @@ static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
 {
     if (dest->base_gfn + dest->npages <= src->base_gfn) {
         // (1)(2)
-        MEMSLOT_DUP(dest);
+        MEMSLOT_ALLOC(dest);
         memslot_insert_before(dest, src);
     } else if (dest->base_gfn <= src->base_gfn) {
         // (3)(4)(5)(6)(7)(8)
         if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
             // (3)(6)
-            MEMSLOT_DUP(dest);
+            MEMSLOT_ALLOC(dest);
             memslot_insert_before(dest, src);
             memslot_overlap_front(dest, src);
         } else {
@@ -495,7 +490,7 @@ static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
             // (9)(10)(11)
             if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
                 // (9)
-                MEMSLOT_DUP(dest);
+                MEMSLOT_ALLOC(dest);
                 memslot_insert_after(dest, src);
                 memslot_insert_after(memslot_append_rest(dest, src), dest);
             }
@@ -511,7 +506,7 @@ static int memslot_process_start_same_type(hax_memslot *dest, hax_memslot *src,
 {
     if (dest->base_gfn + dest->npages < src->base_gfn) {
         // (1)
-        MEMSLOT_DUP(dest);
+        MEMSLOT_ALLOC(dest);
         memslot_insert_before(dest, src);
         return 0;
     }
@@ -588,13 +583,13 @@ static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
             memslot_overlap_front(dest, src);
         }
         if (*state & MEMSLOT_TO_INSERT) {
-            MEMSLOT_DUP(dest);
+            MEMSLOT_ALLOC(dest);
             memslot_insert_before(dest, src);
         }
     } else {
         // [3]
         if (*state & MEMSLOT_TO_INSERT) {
-            memslot_move(src, dest);
+            memslot_copy(src, dest);
         } else {
             memslot_delete(src);
         }
@@ -734,13 +729,21 @@ static void mapping_calc_change(memslot_mapping *mapping, hax_memslot *src,
     }
 }
 
-static inline int mapping_enqueue(hax_list_head *memslot_list,
-                                  hax_memslot *slot)
+static inline void mapping_enqueue(hax_list_head *memslot_list,
+                                   hax_memslot *dest)
 {
-    MEMSLOT_DUP(slot);
-    hax_list_insert_before(&slot->entry, memslot_list);
+    hax_memslot *ptr = NULL;
 
-    return 0;
+    if (dest == NULL)
+        return;
+
+    ptr = (hax_memslot *)hax_vmalloc(sizeof(hax_memslot), HAX_MEM_NONPAGE);
+
+    if (ptr == NULL)
+        return;
+
+    *ptr = *dest;
+    hax_list_insert_before(&ptr->entry, memslot_list);
 }
 
 static inline void mapping_intersect(memslot_mapping *dest,

--- a/core/memslot.c
+++ b/core/memslot.c
@@ -35,6 +35,7 @@
 #define MEMSLOT_PROCESSING 0x01
 #define MEMSLOT_TO_INSERT  0x02
 
+#define MEMSLOT_DUP(m) if (((m) = memslot_dup(m)) == NULL) return -ENOMEM
 #define SAFE_CALL(f) if ((f) != NULL) (f)
 
 enum callback {
@@ -88,8 +89,6 @@ static int memslot_process_end_same_type(hax_memslot *dest, hax_memslot *src,
                                          uint8 *state);
 static int memslot_process_end_invalid(hax_memslot *dest, hax_memslot *src,
                                        uint8 *state);
-static int memslot_list_enqueue(hax_list_head *memslot_list, hax_memslot *dest);
-static void memslot_list_clear(hax_list_head *memslot_list);
 static void mapping_broadcast(hax_list_head *listener_list,
                               memslot_mapping *mapping, hax_memslot *dest,
                               hax_list_head *memslot_list);
@@ -97,6 +96,7 @@ static void mapping_calc_change(memslot_mapping *mapping, hax_memslot *src,
                                 bool is_valid, bool is_terminal,
                                 bool is_changed, memslot_mapping *hole,
                                 memslot_mapping *slot);
+static int mapping_enqueue(hax_list_head *memslot_list, hax_memslot *dest);
 static void mapping_intersect(memslot_mapping *dest, memslot_mapping *src);
 static bool mapping_is_changed(hax_memslot *dest, hax_memslot *src,
                                bool is_valid, bool is_terminal);
@@ -128,10 +128,15 @@ int memslot_init_list(hax_gpa_space *gpa_space)
 
 void memslot_free_list(hax_gpa_space *gpa_space)
 {
+    hax_memslot *memslot = NULL, *n = NULL;
+
     if (gpa_space == NULL)
         return;
 
-    memslot_list_clear(&gpa_space->memslot_list);
+    hax_list_entry_for_each_safe(memslot, n, &gpa_space->memslot_list,
+                                 hax_memslot, entry) {
+        memslot_delete(memslot);
+    }
 }
 
 void memslot_dump_list(hax_gpa_space *gpa_space)
@@ -156,10 +161,10 @@ void memslot_dump_list(hax_gpa_space *gpa_space)
 int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                         uint64 npages, uint64 uva, uint8 flags)
 {
-    hax_memslot memslot, *src = NULL, *dest = &memslot, *m = NULL;
+    hax_memslot memslot, *src = NULL, *dest = &memslot, *n = NULL;
     hax_ramblock *block = NULL;
     memslot_mapping mapping;
-    hax_list_head snapshot;
+    hax_list_head memslot_list;
     int ret = 0;
     bool is_valid = false, is_found = false;
     uint8 route = 0, state = 0;
@@ -193,14 +198,9 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                                 ? uva - dest->block->base_uva : 0;
     dest->flags    = flags;
 
-    hax_init_list_head(&snapshot);
-
     if (hax_list_empty(&gpa_space->memslot_list)) {
         if (is_valid) {
-            if ((dest = memslot_dup(dest)) == NULL) {
-                ret = -ENOMEM;
-                goto out;
-            }
+            MEMSLOT_DUP(dest);
             memslot_insert_head(dest, gpa_space);
 
             mapping_broadcast(&gpa_space->listener_list, &mapping, dest, NULL);
@@ -209,7 +209,9 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
         goto out;
     }
 
-    hax_list_entry_for_each_safe(src, m, &gpa_space->memslot_list, hax_memslot,
+    hax_init_list_head(&memslot_list);
+
+    hax_list_entry_for_each_safe(src, n, &gpa_space->memslot_list, hax_memslot,
                                  entry) {
         if (!is_found) {
             if (dest->base_gfn > src->base_gfn + src->npages) {
@@ -217,18 +219,14 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                     continue;
 
                 if (is_valid) {
-                    if ((dest = memslot_dup(dest)) == NULL) {
-                        ret = -ENOMEM;
-                        goto out;
-                    }
+                    MEMSLOT_DUP(dest);
                     memslot_insert_after(dest, src);
                 }
                 break;
             }
 
             if (dest->base_gfn < src->base_gfn + src->npages) {
-                if ((ret = memslot_list_enqueue(&snapshot, src)) != 0)
-                    goto out;
+                mapping_enqueue(&memslot_list, src);
             }
 
             if (dest->base_gfn + dest->npages >= src->base_gfn + src->npages) {
@@ -237,7 +235,8 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
 
             route = is_valid ? memslot_is_same_type(dest, src)
                     : MAPPING_INVALID;
-            if ((ret = memslot_process_start[route](dest, src, &state)) != 0)
+            ret = memslot_process_start[route](dest, src, &state);
+            if (ret != 0)
                 goto out;
 
             is_found = true;
@@ -246,8 +245,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
                 break;
 
             if (dest->base_gfn + dest->npages > src->base_gfn) {
-                if ((ret = memslot_list_enqueue(&snapshot, src)) != 0)
-                    goto out;
+                mapping_enqueue(&memslot_list, src);
             }
 
             if (memslot_is_inner(dest, src, gpa_space)) {
@@ -257,7 +255,8 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
 
             route = is_valid ? memslot_is_same_type(dest, src)
                     : MAPPING_INVALID;
-            if ((ret = memslot_process_end[route](dest, src, &state)) != 0)
+            ret = memslot_process_end[route](dest, src, &state);
+            if (ret != 0)
                 goto out;
 
             state = 0;
@@ -268,14 +267,12 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
     }
 
     if (state & MEMSLOT_TO_INSERT) {
-        if ((dest = memslot_dup(dest)) == NULL) {
-            ret = -ENOMEM;
-            goto out;
-        }
+        MEMSLOT_DUP(dest);
         memslot_insert_before(dest, src);
     }
 
-    mapping_broadcast(&gpa_space->listener_list, &mapping, dest, &snapshot);
+    mapping_broadcast(&gpa_space->listener_list, &mapping, dest,
+                      &memslot_list);
 
 out:
     // ramblock_find() was invoked previously in this function and returned a
@@ -286,7 +283,6 @@ out:
     if (block != NULL) {
         ramblock_deref(block);
     }
-    memslot_list_clear(&snapshot);
     return ret;
 }
 
@@ -473,23 +469,15 @@ static bool memslot_is_inner(hax_memslot *dest, hax_memslot *src,
 static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
                                            uint8 *state)
 {
-    int ret = 0;
-
     if (dest->base_gfn + dest->npages <= src->base_gfn) {
         // (1)(2)
-        if ((dest = memslot_dup(dest)) == NULL) {
-            ret = -ENOMEM;
-            goto out;
-        }
+        MEMSLOT_DUP(dest);
         memslot_insert_before(dest, src);
     } else if (dest->base_gfn <= src->base_gfn) {
         // (3)(4)(5)(6)(7)(8)
         if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
             // (3)(6)
-            if ((dest = memslot_dup(dest)) == NULL) {
-                ret = -ENOMEM;
-                goto out;
-            }
+            MEMSLOT_DUP(dest);
             memslot_insert_before(dest, src);
             memslot_overlap_front(dest, src);
         } else {
@@ -507,38 +495,23 @@ static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
             // (9)(10)(11)
             if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
                 // (9)
-                hax_memslot *rest = NULL;
-
-                if ((dest = memslot_dup(dest)) == NULL) {
-                    ret = -ENOMEM;
-                    goto out;
-                }
+                MEMSLOT_DUP(dest);
                 memslot_insert_after(dest, src);
-                if ((rest = memslot_append_rest(dest, src)) == NULL) {
-                    ret = -ENOMEM;
-                    goto out;
-                }
-                memslot_insert_after(rest, dest);
+                memslot_insert_after(memslot_append_rest(dest, src), dest);
             }
             memslot_overlap_rear(dest, src);
         }
     }
 
-out:
-    return ret;
+    return 0;
 }
 
 static int memslot_process_start_same_type(hax_memslot *dest, hax_memslot *src,
                                            uint8 *state)
 {
-    int ret = 0;
-
     if (dest->base_gfn + dest->npages < src->base_gfn) {
         // (1)
-        if ((dest = memslot_dup(dest)) == NULL) {
-            ret = -ENOMEM;
-            goto out;
-        }
+        MEMSLOT_DUP(dest);
         memslot_insert_before(dest, src);
         return 0;
     }
@@ -550,15 +523,12 @@ static int memslot_process_start_same_type(hax_memslot *dest, hax_memslot *src,
     // (2)(3)(4)(5)(8)(11)(12)
     memslot_union(dest, src);
 
-out:
-    return ret;
+    return 0;
 }
 
 static int memslot_process_start_invalid(hax_memslot *dest, hax_memslot *src,
                                          uint8 *state)
 {
-    int ret = 0;
-
     if ((dest->base_gfn + dest->npages <= src->base_gfn) ||
         (dest->base_gfn == src->base_gfn + src->npages))
         // (1)(2)(12)
@@ -577,19 +547,12 @@ static int memslot_process_start_invalid(hax_memslot *dest, hax_memslot *src,
         // (9)(10)(11)
         if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
             // (9)
-            hax_memslot *rest = NULL;
-
-            if ((rest = memslot_append_rest(dest, src)) == NULL) {
-                ret = -ENOMEM;
-                goto out;
-            }
-            memslot_insert_after(rest, src);
+            memslot_insert_after(memslot_append_rest(dest, src), src);
         }
         memslot_overlap_rear(dest, src);
     }
 
-out:
-    return ret;
+    return 0;
 }
 
 // =================================================
@@ -618,8 +581,6 @@ out:
 static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
                                          uint8 *state)
 {
-    int ret = 0;
-
     if (dest->base_gfn + dest->npages < src->base_gfn + src->npages) {
         // [1][2]
         if (dest->base_gfn + dest->npages > src->base_gfn) {
@@ -627,10 +588,7 @@ static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
             memslot_overlap_front(dest, src);
         }
         if (*state & MEMSLOT_TO_INSERT) {
-            if ((dest = memslot_dup(dest)) == NULL) {
-                ret = -ENOMEM;
-                goto out;
-            }
+            MEMSLOT_DUP(dest);
             memslot_insert_before(dest, src);
         }
     } else {
@@ -642,8 +600,7 @@ static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
         }
     }
 
-out:
-    return ret;
+    return 0;
 }
 
 static int memslot_process_end_same_type(hax_memslot *dest, hax_memslot *src,
@@ -686,33 +643,6 @@ static int memslot_process_end_invalid(hax_memslot *dest, hax_memslot *src,
     }
 
     return 0;
-}
-
-static inline int memslot_list_enqueue(hax_list_head *memslot_list,
-                                       hax_memslot *memslot)
-{
-    int ret = 0;
-
-    if ((memslot = memslot_dup(memslot)) == NULL) {
-        ret = -ENOMEM;
-        goto out;
-    }
-    hax_list_insert_before(&memslot->entry, memslot_list);
-
-out:
-    return ret;
-}
-
-static inline void memslot_list_clear(hax_list_head *memslot_list)
-{
-    hax_memslot *memslot = NULL, *m = NULL;
-
-    if (hax_list_empty(memslot_list))
-        return;
-
-    hax_list_entry_for_each_safe(memslot, m, memslot_list, hax_memslot, entry) {
-        memslot_delete(memslot);
-    }
 }
 
 static void mapping_broadcast(hax_list_head *listener_list,
@@ -802,6 +732,15 @@ static void mapping_calc_change(memslot_mapping *mapping, hax_memslot *src,
     } else {
         slot->callback = 0;
     }
+}
+
+static inline int mapping_enqueue(hax_list_head *memslot_list,
+                                  hax_memslot *slot)
+{
+    MEMSLOT_DUP(slot);
+    hax_list_insert_before(&slot->entry, memslot_list);
+
+    return 0;
 }
 
 static inline void mapping_intersect(memslot_mapping *dest,

--- a/core/ramblock.c
+++ b/core/ramblock.c
@@ -93,8 +93,6 @@ static hax_ramblock * ramblock_alloc(uint64 base_uva, uint64 size)
     }
     memset(chunks_bitmap, 0, chunks_bitmap_size);
     block->chunks_bitmap = chunks_bitmap;
-    block->ref_count = 0;
-
     return block;
 }
 
@@ -159,14 +157,6 @@ static void ramblock_free(hax_ramblock *block)
     hax_vfree(block, sizeof(*block));
 }
 
-static inline void ramblock_remove(hax_ramblock *block)
-{
-    hax_list_del(&block->entry);
-    ramblock_info("%s: Removed RAM block: uva: 0x%llx, size: 0x%llx, ref_count: %d\n",
-                  __func__, block->base_uva, block->size, block->ref_count);
-    ramblock_free(block);
-}
-
 int ramblock_init_list(hax_list_head *list)
 {
     if (!list) {
@@ -190,7 +180,10 @@ void ramblock_free_list(hax_list_head *list)
 
     ramblock_info("ramblock_free_list\n");
     hax_list_entry_for_each_safe(ramblock, tmp, list, hax_ramblock, entry) {
-        ramblock_remove(ramblock);
+        hax_list_del(&ramblock->entry);
+        ramblock_info("ramblock_free_list: freeing block: uva:0x%llx,"
+                      " size:0x%llx \n", ramblock->base_uva, ramblock->size);
+        ramblock_free(ramblock);
     }
 }
 
@@ -201,9 +194,8 @@ void ramblock_dump_list(hax_list_head *list)
 
     ramblock_info("ramblock dump begin:\n");
     hax_list_entry_for_each(ramblock, list, hax_ramblock, entry) {
-        ramblock_info("block %d (%p): base_uva 0x%llx, size 0x%llx, ref_count "
-                      "%d\n", i++, ramblock, ramblock->base_uva,
-                      ramblock->size, ramblock->ref_count);
+        ramblock_info("block %d: base_uva 0x%llx, size 0x%llx\n",
+                      i++, ramblock->base_uva, ramblock->size);
     }
     ramblock_info("ramblock dump end!\n");
 }
@@ -218,14 +210,8 @@ hax_ramblock * ramblock_find(hax_list_head *list, uint64 uva,
         if (ramblock->base_uva > uva)
             break;
 
-        if (uva < ramblock->base_uva + ramblock->size) {
-            hax_debug("%s: (%p): base_uva 0x%llx, size 0x%llx, ref_count "
-                      "%d\n", __func__, ramblock, ramblock->base_uva,
-                      ramblock->size, ramblock->ref_count);
-
-            ramblock_ref(ramblock);
+        if (uva < ramblock->base_uva + ramblock->size)
             return ramblock;
-        }
     }
 
     hax_warning("can not find 0x%llx in ramblock list.\n", uva);
@@ -376,34 +362,4 @@ hax_chunk * ramblock_get_chunk(hax_ramblock *block, uint64 uva_offset,
     }
 done:
     return block->chunks[chunk_index];
-}
-
-void ramblock_ref(hax_ramblock *block)
-{
-    if (block == NULL) {
-        hax_error("%s: Invalid RAM block\n", __func__);
-        return;
-    }
-
-    ++block->ref_count;
-    hax_debug("%s: block (%p): base_uva = 0x%llx, size = 0x%llx, ref_count = "
-              "%d\n", __func__, block, block->base_uva, block->size,
-              block->ref_count);
-}
-
-void ramblock_deref(hax_ramblock *block)
-{
-    if (block == NULL) {
-        hax_error("%s: Invalid RAM block\n", __func__);
-        return;
-    }
-
-    if (--block->ref_count == 0) {
-        ramblock_remove(block);
-        return;
-    }
-
-    hax_debug("%s: block (%p): base_uva = 0x%llx, size = 0x%llx, ref_count = "
-              "%d\n", __func__, block, block->base_uva, block->size,
-              block->ref_count);
 }


### PR DESCRIPTION
These two previous patches were used for enabling reference counting for RAM blocks. However, currently this algorithm had not been complete. It cannot cover to handle RAM block mapping approaches of some platforms, such as Debian and ChromeOS. During the launching process of these platforms, some RAM blocks were erased by setting a same size MMIO mapping, which operation results in the destroy of RAM blocks. It will fail to set this block to RAM/ROM again because there is no allocation operation for this RAM block before setting. Revert these two patches to restore destroying RAM blocks during the system exits.