### PR TITLE
page_walker: Fix 32-bit GVA-GPA translation bug

### DIFF
--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -415,7 +415,10 @@ static uint64 pw_retrieve_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae)
         return ((uint64)addr_high << PW_HIGH_ADDRESS_SHIFT) | addr_low;
     }
 
-    return entry->non_pae_entry.bits.addr_base << PW_TABLE_SHIFT;
+    // Must convert the uint32 bit-field to uint64 before the shift. Otherwise,
+    // on Mac the shift result will be sign-extended to 64 bits (Clang bug?),
+    // yielding invalid GPAs such as 0xffffffff801c8000.
+    return (uint64)entry->non_pae_entry.bits.addr_base << PW_TABLE_SHIFT;
 }
 
 static uint64 pw_retrieve_big_page_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae,


### PR DESCRIPTION
On Mac, with certain 32-bit guests (PAE off), vcpu_translate()
sometimes fails or yields an invalid GPA like 0xffffffff801c8000.
The root cause is that Clang somehow uses sign extension when
converting the result of left-shifting a uint32_t bit-field to
uint64_t.

If the bit-field is first converted to uint64_t and then shifted,
the end result will be correct. With this patch, one is able to
boot debian_squeeze_i386_desktop.qcow2 with a sufficiently large
guest RAM size (e.g. 3GB) on Mac.