### PR TITLE
windows: Use queued spin locks

### DIFF
--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -102,8 +102,11 @@ typedef struct hax_kmap_phys {
 
 typedef struct {
     KSPIN_LOCK lock;
-    uint32_t flags;
-    KIRQL old_irq;
+    // According to MSDN:
+    //  https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/queued-spin-locks
+    // "Drivers for Windows XP and later versions of Windows should use queued
+    // spin locks instead of ordinary spin locks."
+    KLOCK_QUEUE_HANDLE handle;
 } hax_spinlock;
 
 typedef FAST_MUTEX *hax_mutex;

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -75,17 +75,14 @@ static inline hax_spinlock *hax_spinlock_alloc_init(void)
 
 static inline void hax_spin_lock(hax_spinlock *lock)
 {
-    KIRQL old_irq;
     ASSERT(lock);
-    KeAcquireSpinLock(&lock->lock, &old_irq);
-    lock->old_irq = old_irq;
+    KeAcquireInStackQueuedSpinLockAtDpcLevel(&lock->lock, &lock->handle);
 }
 
-/* Do we need a flag to track if old_irq is valid? */
 static inline void hax_spin_unlock(hax_spinlock *lock)
 {
     ASSERT(lock);
-    KeReleaseSpinLock(&lock->lock, lock->old_irq);
+    KeReleaseInStackQueuedSpinLockFromDpcLevel(&lock->handle);
 }
 
 static inline hax_mutex hax_mutex_alloc_init(void)


### PR DESCRIPTION
Replace the Windows implementation of hax_spinlock with the
"queued" variant, which is available on all Windows versions that
HAXM supports, and offers better performance according to MSDN.