### PR TITLE
Revert "windows: Use queued spin locks"

### DIFF
--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -102,11 +102,8 @@ typedef struct hax_kmap_phys {
 
 typedef struct {
     KSPIN_LOCK lock;
-    // According to MSDN:
-    //  https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/queued-spin-locks
-    // "Drivers for Windows XP and later versions of Windows should use queued
-    // spin locks instead of ordinary spin locks."
-    KLOCK_QUEUE_HANDLE handle;
+    uint32_t flags;
+    KIRQL old_irq;
 } hax_spinlock;
 
 typedef FAST_MUTEX *hax_mutex;

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -75,14 +75,17 @@ static inline hax_spinlock *hax_spinlock_alloc_init(void)
 
 static inline void hax_spin_lock(hax_spinlock *lock)
 {
+    KIRQL old_irq;
     ASSERT(lock);
-    KeAcquireInStackQueuedSpinLockAtDpcLevel(&lock->lock, &lock->handle);
+    KeAcquireSpinLock(&lock->lock, &old_irq);
+    lock->old_irq = old_irq;
 }
 
+/* Do we need a flag to track if old_irq is valid? */
 static inline void hax_spin_unlock(hax_spinlock *lock)
 {
     ASSERT(lock);
-    KeReleaseInStackQueuedSpinLockFromDpcLevel(&lock->handle);
+    KeReleaseSpinLock(&lock->lock, lock->old_irq);
 }
 
 static inline hax_mutex hax_mutex_alloc_init(void)


### PR DESCRIPTION
This reverts commit 5cfb841f8d19202e3fd70907ae07f4101ab3c478.

The said patch is seriously flawed:

1. It calls the wrong Windows Driver Kit functions. E.g.,
   KeAcquireInStackQueuedSpinLockAtDpcLevel() should only be called
   when IRQL = DISPATCH_LEVEL, but most of HAXM code runs below
   that level. The more general KeAcquireInStackQueuedSpinLock()
   should be used instead.
2. Unlike the release of a regular spin lock, which is a simple
   operation, the release of a queued spin lock needs to wait for a
   condition and thus may block. If called from a function that
   should never block, e.g. ept_tree_alloc_page(), a deadlock may
   occur.

Fall back to regular spin locks which do not block on release.