### PR TITLE
Added IA32_TSC_AUX MSR

### DIFF
--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -71,6 +71,8 @@ struct hstate {
     uint64 apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1
     uint64 apm_pes_msrs[APM_MAX_GENERAL_COUNT];
+    // IA32_TSC_AUX
+    uint64 tsc_aux;
     struct hax_page *hfxpage;
     uint64 fake_gs;
     system_desc_t host_gdtr;

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -185,7 +185,8 @@ enum {
     IA32_SF_MASK                 = 0xc0000084,
     IA32_FS_BASE                 = 0xc0000100,
     IA32_GS_BASE                 = 0xc0000101,
-    IA32_KERNEL_GS_BASE          = 0xc0000102
+    IA32_KERNEL_GS_BASE          = 0xc0000102,
+    IA32_TSC_AUX                 = 0xc0000103
 };
 
 // EFER bits
@@ -302,6 +303,7 @@ enum {
 
     feat_syscall            = 1U << 11,      // 0x800
     feat_execute_disable    = 1U << 20,      // 0x10000
+    feat_rdtscp             = 1U << 27,      // 0x8000000
     feat_em64t              = 1U << 29       // 0x20000000
 };
 

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -49,6 +49,8 @@ struct gstate {
     uint64 apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1
     uint64 apm_pes_msrs[APM_MAX_GENERAL_COUNT];
+    // IA32_TSC_AUX
+    uint64 tsc_aux;
     struct hax_page *gfxpage;
     // APIC_BASE MSR
     uint64 apic_base;


### PR DESCRIPTION
My guest system relies on `IA32_TSC_AUX` and this patch allows it to boot further.

Since `handle_cpuid_virtual` always returns a constant set of features, I have skipped the check for the `feat_rdtscp` flag before reading/writing this register and simply added it to `gmsr_list`. Note that the `rdtscp` instruction not yet implemented in the emulator, since none of my guests used it, but I can implement it for the sake of consistency if you want.