### PR TITLE
Added bextr/andn instructions to emulator

### DIFF
--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -176,6 +176,22 @@ typedef struct em_context_t {
     uint64_t rflags;
 
     /* Decoder */
+    struct {
+        uint8_t prefix;
+        union {
+            struct {
+                uint8_t m : 5;
+                uint8_t b : 1;
+                uint8_t x : 1;
+                uint8_t r : 1;
+                uint8_t p : 2;
+                uint8_t l : 1;
+                uint8_t v : 4;
+                uint8_t w : 1;
+            };
+            uint16_t value;
+        };
+    } vex;
     union {
         struct {
             uint8_t b : 1;


### PR DESCRIPTION
This adds support for decoding VEX prefixes and emulating the `bextr` and `andn` instructions, with which some some guest kernels do MMIO accesses.

Since these instructions are part of the BMI1 extension, using the "*fast handlers*": `em_bextr` and  `em_andn`, i.e. running a register-only version of the instruction would be an issue on pre-Haswell CPUs. Until we implement a way to detect host features, I've added software-emulated handlers `em_bextr_soft` and `em_andn_soft`, respectively.