### PR TITLE
core: fix bug that INVEPT is not invoked on Mac

### DIFF
--- a/core/ept.c
+++ b/core/ept.c
@@ -330,22 +330,13 @@ static void invept_smpfunc(struct invept_bundle *bundle)
 
     smp_mb();
     cpu_data = current_cpu_data();
-    cpu_data->vmxon_err = VMX_SUCCEED;
-    cpu_data->vmxoff_err = VMX_SUCCEED;
     cpu_data->invept_err = VMX_SUCCEED;
 
-    cpu_data->host_cr4_vmxe = get_cr4() & CR4_VMXE;
-    set_cr4(get_cr4() | CR4_VMXE);
-    cpu_data->vmxon_err = __vmxon(hax_page_pa(cpu_data->vmxon_page));
+    cpu_vmxroot_enter();
 
     if (!(cpu_data->vmxon_err & VMX_FAIL_MASK)) {
         cpu_data->invept_err = __invept(bundle->type, bundle->desc);
-        cpu_data->vmxoff_err = __vmxoff();
-        if (cpu_data->host_cr4_vmxe) {
-            set_cr4(get_cr4() | CR4_VMXE);
-        } else {
-            set_cr4(get_cr4() & ~CR4_VMXE);
-        }
+        cpu_vmxroot_leave();
     }
 }
 

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -165,7 +165,6 @@ static vmcs_t * current_cpu_vmcs(void)
 
 void cpu_init_vmx(void *arg);
 void cpu_exit_vmx(void *arg);
-void cpu_enter_vmx(void *arg);
 
 void cpu_pmu_init(void *arg);
 
@@ -181,6 +180,9 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun);
 vmx_error_t vmptrld(paddr_t vmcs, struct vcpu_t *vcpu);
 vmx_error_t resume(paddr_t vmcs, struct vcpu_t *vcpu);
 vmx_error_t launch(paddr_t vmcs, struct vcpu_t *vcpu);
+
+vmx_error_t cpu_vmxroot_leave(void);
+vmx_error_t cpu_vmxroot_enter(void);
 
 extern struct hax_page *io_bitmap_page_a;
 extern struct hax_page *io_bitmap_page_b;


### PR DESCRIPTION
There is coexistence issue in MacOS when some Mac VMMs are running
at the same time. invept might not be invoked due to coexistence
issue. This change is to fix the issue that invept is not invoked.

It also refactors the existed logic for VMXON/VMXOFF into two
functions. The function names come from PR #49.