### PR TITLE
darwin: Move preemption helpers out of vmcs.c

### DIFF
--- a/darwin/hax_driver/com_intel_hax/asm/vmcs.c
+++ b/darwin/hax_driver/com_intel_hax/asm/vmcs.c
@@ -28,37 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../../core/include/ia32.h"
 #include "../../../../core/include/vmx.h"
 #include "../../../../core/include/types.h"
-#include "../../../../include/hax.h"
 #include "../../../../core/include/vcpu.h"
-
-void hax_disable_preemption(preempt_flag *eflags)
-{
-    mword flags;
-#ifdef __x86_64__
-    asm volatile (
-        "pushfq         \n\t"
-        "popq %0"
-        : "=r" (flags)
-    );
-#else
-    asm volatile (
-        "pushfd         \n\t"
-        "pop %0"
-        : "=r" (flags)
-    );
-#endif
-    *eflags = flags;
-    hax_disable_irq();
-}
-
-void hax_enable_preemption(preempt_flag *eflags)
-{
-    if (*eflags & EFLAGS_IF)
-        hax_enable_irq();
-}
 
 /* Don't call these two functions as NOT INLINE manner */
 #ifdef __i386__


### PR DESCRIPTION
hax_disable_preemption() and hax_enable_preemption() do not belong
to vmcs.c, since they do not use any VMX instruction. Move them to
hax_wrapper.cpp, in the same way that their  Windows counterparts
are defined in windows/hax_wrapper.c.