### PR TITLE
core: fix an assert boundary checking issue

### DIFF
--- a/core/gpa_space.c
+++ b/core/gpa_space.c
@@ -406,7 +406,7 @@ static inline void set_bits_in_byte(uint8 *byte, int start, int nbits, bool set)
 
     assert(byte != NULL);
     assert(start >= 0 && start < 8);
-    assert(nbits >= 0 && start + nbits < 8);
+    assert(nbits >= 0 && start + nbits <= 8);
 
     mask = ((1 << nbits) - 1) << start;
     if (set) {


### PR DESCRIPTION
There is a small boundary issue in core, which makes false alarm.
start + nbits could be equal with or less than 8 (byte size).