### PR TITLE
Refactor ia32.h and vmx.h

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -29,7 +29,7 @@
  */
 
 #include "../include/hax.h"
-#include "include/ia32.h"
+#include "include/ia32_defs.h"
 #include "include/cpu.h"
 #include "include/cpuid.h"
 #include "include/vcpu.h"

--- a/core/cpuid.c
+++ b/core/cpuid.c
@@ -29,7 +29,8 @@
  */
 
 #include "include/cpuid.h"
-#include "../include/asm.h"
+
+#include "include/ia32.h"
 
 typedef union cpuid_feature_t {
     struct {

--- a/core/dump_vmcs.c
+++ b/core/dump_vmcs.c
@@ -30,6 +30,7 @@
 
 #include "include/vmx.h"
 #include "include/dump_vmcs.h"
+#include "include/compiler.h"
 #include "../include/hax.h"
 
 extern unsigned char **vmcs_names;

--- a/core/hax.c
+++ b/core/hax.c
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/ia32.h"
+#include "include/ia32_defs.h"
 #include "include/vmx.h"
 
 #include "include/cpu.h"

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -35,9 +35,6 @@ struct qword_val {
     uint32 high;
 };
 
-extern void ASMCALL asm_enable_irq(void);
-extern void ASMCALL asm_disable_irq(void);
-
 #ifdef _M_IX86
 extern void ASMCALL asm_rdmsr(uint32 reg, struct qword_val *qv);
 extern void ASMCALL asm_wrmsr(uint32 reg, struct qword_val *qv);
@@ -114,15 +111,3 @@ void bts(uint8 *addr, uint bit)
     uint offset = bit % 8;
     asm_bts(base, offset);
 }
-
-#ifndef __MACH__
-void hax_enable_irq(void)
-{
-    asm_enable_irq();
-}
-
-void hax_disable_irq(void)
-{
-    asm_disable_irq();
-}
-#endif

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -38,9 +38,6 @@ struct qword_val {
 extern void ASMCALL asm_enable_irq(void);
 extern void ASMCALL asm_disable_irq(void);
 
-extern mword ASMCALL asm_vmread(uint32 component);
-extern void ASMCALL asm_vmwrite(uint32 component, mword val);
-
 #ifdef _M_IX86
 extern void ASMCALL asm_rdmsr(uint32 reg, struct qword_val *qv);
 extern void ASMCALL asm_wrmsr(uint32 reg, struct qword_val *qv);
@@ -116,65 +113,6 @@ void bts(uint8 *addr, uint bit)
     uint8 *base = addr + bit / 8;
     uint offset = bit % 8;
     asm_bts(base, offset);
-}
-
-struct vcpu_t;
-
-void _vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
-                  component_index_t component,
-                  mword source_val)
-{
-    asm_vmwrite(component, source_val);
-}
-
-void _vmx_vmwrite_64(struct vcpu_t *vcpu, const char *name,
-                     component_index_t component,
-                     uint64 source_val)
-{
-#ifdef _M_IX86
-    asm_vmwrite(component, (uint32)source_val);
-    asm_vmwrite(component + 1, (uint32)(source_val >> 32));
-#else
-    asm_vmwrite(component, source_val);
-#endif
-}
-
-void _vmx_vmwrite_natural(struct vcpu_t *vcpu, const char *name,
-                          component_index_t component,
-                          uint64 source_val)
-{
-#ifdef _M_IX86
-    asm_vmwrite(component, (uint32)source_val);
-#else
-    asm_vmwrite(component, source_val);
-#endif
-}
-
-uint64 vmx_vmread(struct vcpu_t *vcpu, component_index_t component)
-{
-    uint64 val = 0;
-
-    val = asm_vmread(component);
-    return val;
-}
-
-uint64 vmx_vmread_natural(struct vcpu_t *vcpu, component_index_t component)
-{
-    uint64 val = 0;
-
-    val = asm_vmread(component);
-    return val;
-}
-
-uint64 vmx_vmread_64(struct vcpu_t *vcpu, component_index_t component)
-{
-    uint64 val = 0;
-
-    val = asm_vmread(component);
-#ifdef _M_IX86
-    val |= ((uint64)(asm_vmread(component + 1)) << 32);
-#endif
-    return val;
 }
 
 #ifndef __MACH__

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -28,8 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../include/hax.h"
-#include "../include/asm.h"
+#include "include/ia32.h"
 
 struct qword_val {
     uint32 low;
@@ -118,6 +117,8 @@ void bts(uint8 *addr, uint bit)
     uint offset = bit % 8;
     asm_bts(base, offset);
 }
+
+struct vcpu_t;
 
 void _vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
                   component_index_t component,

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -177,9 +177,10 @@ void hax_clear_panic_log(struct vcpu_t *vcpu);
 vmx_result_t cpu_vmx_run(struct vcpu_t *vcpu, struct hax_tunnel *htun);
 int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun);
 
-vmx_result_t vmptrld(paddr_t vmcs, struct vcpu_t *vcpu);
-vmx_result_t resume(paddr_t vmcs, struct vcpu_t *vcpu);
-vmx_result_t launch(paddr_t vmcs, struct vcpu_t *vcpu);
+void load_vmcs_common(struct vcpu_t *vcpu);
+uint32 load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
+uint32 put_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
+uint8 is_vmcs_loaded(struct vcpu_t *vcpu);
 
 vmx_result_t cpu_vmxroot_leave(void);
 vmx_result_t cpu_vmxroot_enter(void);

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -31,7 +31,7 @@
 #ifndef HAX_CORE_CPUID_H_
 #define HAX_CORE_CPUID_H_
 
-#include "hax_types.h"
+#include "../../include/hax_types.h"
 
 #define CPUID_CACHE_SIZE 6
 

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -34,7 +34,7 @@
 #ifdef HAX_TESTS
 #include <stdint.h>
 #else
-#include "hax_types.h"
+#include "../../include/hax_types.h"
 #endif
 
 #include "emulate_ops.h"

--- a/core/include/ept.h
+++ b/core/include/ept.h
@@ -198,11 +198,6 @@ static void construct_eptp(eptp_t *entry, paddr_t hpa, uint emt)
 #define EPT_INVEPT_SINGLE_CONTEXT 1
 #define EPT_INVEPT_ALL_CONTEXT    2
 
-struct invept_desc {
-    uint64 eptp;
-    uint64 rsvd;
-};
-
 bool ept_init(hax_vm_t *hax_vm);
 void ept_free(hax_vm_t *hax_vm);
 

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -92,6 +92,9 @@ void fxrstor(mword *addr);
 void btr(uint8 *addr, uint bit);
 void bts(uint8 *addr, uint bit);
 
+void ASMCALL asm_enable_irq(void);
+void ASMCALL asm_disable_irq(void);
+
 uint64 ASMCALL get_kernel_rflags(void);
 uint16 ASMCALL get_kernel_tr_selector(void);
 

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -28,10 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HAX_ASM_H_
-#define HAX_ASM_H_
+#ifndef HAX_CORE_IA32_H_
+#define HAX_CORE_IA32_H_
 
-#include "hax_types.h"
+#include "../../include/hax_types.h"
 
 union cpuid_args_t;
 struct system_desc_t;
@@ -102,4 +102,4 @@ void ASMCALL get_kernel_gdt(struct system_desc_t *sys_desc);
 void ASMCALL get_kernel_idt(struct system_desc_t *sys_desc);
 uint16 ASMCALL get_kernel_ldt(void);
 
-#endif  // HAX_ASM_H_
+#endif  // HAX_CORE_IA32_H_

--- a/core/include/ia32_defs.h
+++ b/core/include/ia32_defs.h
@@ -28,12 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HAX_CORE_IA32_H_
-#define HAX_CORE_IA32_H_
-
-#include "types.h"
-#include "segments.h"
-#include "../../include/hax.h"
+#ifndef HAX_CORE_IA32_DEFS_H_
+#define HAX_CORE_IA32_DEFS_H_
 
 #define IA32_FXSAVE_SIZE 512
 
@@ -255,4 +251,4 @@ enum {
 
 #define IA32_VMX_MISC_UG_AVAILABLE (0x0000000000000020)
 
-#endif  // HAX_CORE_IA32_H_
+#endif  // HAX_CORE_IA32_DEFS_H_

--- a/core/include/mtrr.h
+++ b/core/include/mtrr.h
@@ -31,8 +31,6 @@
 #ifndef HAX_CORE_MTRR_H_
 #define HAX_CORE_MTRR_H_
 
-#include "ia32.h"
-
 #define NUM_FIXED_MTRRS    11
 #define NUM_VARIABLE_MTRRS 10
 

--- a/core/include/paging.h
+++ b/core/include/paging.h
@@ -31,9 +31,7 @@
 #ifndef HAX_CORE_PAGING_H_
 #define HAX_CORE_PAGING_H_
 
-#include "../../include/hax_types.h"
-#include "types.h"
-#include "ia32.h"
+#include "../../include/hax.h"
 
 #define PM_INVALID    0
 #define PM_FLAT       1

--- a/core/include/segments.h
+++ b/core/include/segments.h
@@ -31,8 +31,9 @@
 #ifndef HAX_CORE_SEGMENTS_H_
 #define HAX_CORE_SEGMENTS_H_
 
-#include "types.h"
-#include "../../include/hax.h"
+#include "ia32.h"
+// TODO: Get rid of is_compatible(), and then delete the following #include
+#include "../../include/hax_interface.h"
 
 #ifdef __WINNT__
 #pragma pack(push, 1)

--- a/core/include/segments.h
+++ b/core/include/segments.h
@@ -32,8 +32,6 @@
 #define HAX_CORE_SEGMENTS_H_
 
 #include "types.h"
-#include "compiler.h"
-#include "ia32.h"
 #include "../../include/hax.h"
 
 #ifdef __WINNT__

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -32,7 +32,6 @@
 #define HAX_CORE_VCPU_H_
 
 #include "emulate.h"
-#include "ia32.h"
 #include "vmx.h"
 #include "mtrr.h"
 #include "vm.h"

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -486,7 +486,10 @@ typedef enum encode_t encode_t;
 #define ENCODE_MASK    0x3
 #define ENCODE_SHIFT    13
 
-struct invept_desc;
+struct invept_desc {
+    uint64 eptp;
+    uint64 rsvd;
+};
 
 vmx_result_t ASMCALL asm_invept(uint type, struct invept_desc *desc);
 vmx_result_t ASMCALL asm_vmclear(const paddr_t *addr_in);

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -31,7 +31,6 @@
 #ifndef HAX_CORE_VMX_H_
 #define HAX_CORE_VMX_H_
 
-#include "ia32.h"
 #include "hax_core_interface.h"
 #define VMCS_NONE 0xFFFFFFFFFFFFFFFF
 

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -497,7 +497,7 @@ vmx_result_t ASMCALL asm_vmptrld(const paddr_t *addr_in);
 vmx_result_t ASMCALL asm_vmxon(const paddr_t *addr_in);
 vmx_result_t ASMCALL asm_vmxoff(void);
 vmx_result_t ASMCALL asm_vmptrst(paddr_t *addr_out);
-uint64 ASMCALL asm_vmxrun(struct vcpu_state_t *state, uint16 launch);
+vmx_result_t ASMCALL asm_vmxrun(struct vcpu_state_t *state, uint16 launch);
 
 mword ASMCALL vmx_get_rip(void);
 

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -486,6 +486,8 @@ typedef enum encode_t encode_t;
 #define ENCODE_MASK    0x3
 #define ENCODE_SHIFT    13
 
+struct invept_desc;
+
 vmx_result_t ASMCALL asm_invept(uint type, struct invept_desc *desc);
 vmx_result_t ASMCALL asm_vmclear(const paddr_t *addr_in);
 vmx_result_t ASMCALL asm_vmptrld(const paddr_t *addr_in);

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -29,6 +29,7 @@
  */
 
 #include "include/intr.h"
+#include "include/ia32_defs.h"
 #include "include/vcpu.h"
 #include "../include/hax.h"
 

--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -29,6 +29,7 @@
  */
 
 #include "../include/hax.h"
+#include "include/ia32_defs.h"
 #include "include/paging.h"
 #include "include/vcpu.h"
 #include "include/vtlb.h"

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -29,7 +29,8 @@
  */
 
 #include "../include/hax.h"
-#include "include/ia32.h"
+#include "include/compiler.h"
+#include "include/ia32_defs.h"
 #include "include/vcpu.h"
 #include "include/mtrr.h"
 #include "include/vmx.h"

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/ia32.h"
+#include "include/ia32_defs.h"
 #include "include/vmx.h"
 #include <string.h>
 #include "include/cpu.h"

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -29,6 +29,7 @@
  */
 
 #include "../include/hax.h"
+#include "include/ia32_defs.h"
 #include "include/paging.h"
 #include "include/vcpu.h"
 #include "include/vtlb.h"

--- a/darwin/hax_driver/com_intel_hax/hax_wrapper.cpp
+++ b/darwin/hax_driver/com_intel_hax/hax_wrapper.cpp
@@ -37,7 +37,7 @@
 #include <stdarg.h>
 #include <sys/proc.h>
 #include "../../../include/hax.h"
-#include "../../../core/include/ia32.h"
+#include "../../../core/include/ia32_defs.h"
 
 extern "C" int vcpu_event_pending(struct vcpu_t *vcpu);
 

--- a/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
+++ b/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
@@ -128,8 +128,8 @@
 		642FD41A20D9F74D00C197FF /* cpuid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpuid.h; sourceTree = "<group>"; };
 		642FD41C20D9F79100C197FF /* emulate_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emulate_ops.h; sourceTree = "<group>"; };
 		642FD41D20D9F79100C197FF /* emulate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emulate.h; sourceTree = "<group>"; };
-		6448A2201EDFCDAB000B4B32 /* hax_host_mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hax_host_mem.h; path = ../../../include/hax_host_mem.h; sourceTree = "<group>"; };
-		6456261E1EEFF705005280EF /* ept2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ept2.h; path = ../../../core/include/ept2.h; sourceTree = "<group>"; };
+		6448A2201EDFCDAB000B4B32 /* hax_host_mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hax_host_mem.h; sourceTree = "<group>"; };
+		6456261E1EEFF705005280EF /* ept2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ept2.h; sourceTree = "<group>"; };
 		645626201EEFF720005280EF /* ept_tree.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ept_tree.c; path = ../../../core/ept_tree.c; sourceTree = "<group>"; };
 		6496936E20D8AE0000C9BBAF /* cpuid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpuid.c; path = ../../../core/cpuid.c; sourceTree = "<group>"; };
 		64B72B841EDFFF7E00A8C202 /* hax_host_mem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hax_host_mem.cpp; sourceTree = "<group>"; };
@@ -163,7 +163,7 @@
 		B98ECFB513A059BB00485DDB /* vmx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vmx.c; path = ../../../core/vmx.c; sourceTree = SOURCE_ROOT; };
 		CF0539AC1EE536CB00FAD569 /* chunk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = chunk.c; path = ../../../core/chunk.c; sourceTree = "<group>"; };
 		CF148D5F1EE6BAEB0097A058 /* memslot.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = memslot.c; path = ../../../core/memslot.c; sourceTree = "<group>"; };
-		CF6A32281EDEB86E00468E62 /* pmu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pmu.h; path = ../../../core/include/pmu.h; sourceTree = "<group>"; };
+		CF6A32281EDEB86E00468E62 /* pmu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pmu.h; sourceTree = "<group>"; };
 		CFB6FDDA1ED43C540048A750 /* ramblock.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ramblock.c; path = ../../../core/ramblock.c; sourceTree = "<group>"; };
 		CFD697461ED2DC9700F10631 /* gpa_space.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gpa_space.c; path = ../../../core/gpa_space.c; sourceTree = "<group>"; };
 		CFD697481ED2DCB700F10631 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
@@ -230,11 +230,9 @@
 				CFB6FDDA1ED43C540048A750 /* ramblock.c */,
 				43440F2F13A3B69A002E1442 /* hax_mem_alloc.cpp */,
 				43440F3013A3B69A002E1442 /* hax_wrapper.cpp */,
-				6448A2201EDFCDAB000B4B32 /* hax_host_mem.h */,
 				64B72B841EDFFF7E00A8C202 /* hax_host_mem.cpp */,
 				64B85BE81EF4D34D00223ABD /* ept2.c */,
 				645626201EEFF720005280EF /* ept_tree.c */,
-				6456261E1EEFF705005280EF /* ept2.h */,
 				B98ECF9C13A059BB00485DDB /* cpu.c */,
 				B98ECF9D13A059BB00485DDB /* dump_vmcs.c */,
 				B98ECF9E13A059BB00485DDB /* hax.c */,
@@ -243,7 +241,6 @@
 				FA8F651D208BAD9A00C8E91F /* emulate.c */,
 				FA8F651F208BC1BA00C8E91F /* emulate_ops.asm */,
 				B98ECFB313A059BB00485DDB /* vm.c */,
-				CF6A32281EDEB86E00468E62 /* pmu.h */,
 				B98ECFB413A059BB00485DDB /* vmcs_names.c */,
 				B98ECFB513A059BB00485DDB /* vmx.c */,
 				43C9A9E6138DDA93000A1071 /* hax_host.h */,
@@ -270,6 +267,7 @@
 				4397BF1A138F4530001A6A33 /* hax.h */,
 				4397BF1C138F4530001A6A33 /* hax_list.h */,
 				4397BF1D138F4530001A6A33 /* hax_types.h */,
+				6448A2201EDFCDAB000B4B32 /* hax_host_mem.h */,
 			);
 			name = include;
 			path = ../../../include;
@@ -286,6 +284,7 @@
 				22BFCFDD13A59AB100AD9F0F /* vtlb.h */,
 				22BFCFDB13A59AA000AD9F0F /* intr.h */,
 				22BFCFD713A59A9100AD9F0F /* ept.h */,
+				6456261E1EEFF705005280EF /* ept2.h */,
 				4324E35513A3781500FA7CFB /* hax_core_interface.h */,
 				B98ECFA013A059BB00485DDB /* compiler.h */,
 				B98ECFA113A059BB00485DDB /* config.h */,
@@ -297,6 +296,7 @@
 				B98ECFA713A059BB00485DDB /* ia32_defs.h */,
 				B98ECFA813A059BB00485DDB /* mtrr.h */,
 				B98ECFA913A059BB00485DDB /* paging.h */,
+				CF6A32281EDEB86E00468E62 /* pmu.h */,
 				B98ECFAA13A059BB00485DDB /* segments.h */,
 				B98ECFAC13A059BB00485DDB /* types.h */,
 				B98ECFAD13A059BB00485DDB /* vcpu.h */,

--- a/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
+++ b/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 		B98ECFBC13A059BB00485DDB /* debug.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA313A059BB00485DDB /* debug.h */; };
 		B98ECFBD13A059BB00485DDB /* dump_vmcs.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA413A059BB00485DDB /* dump_vmcs.h */; };
 		B98ECFBE13A059BB00485DDB /* hax_driver.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA513A059BB00485DDB /* hax_driver.h */; };
-		B98ECFC013A059BB00485DDB /* ia32.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA713A059BB00485DDB /* ia32.h */; };
+		B98ECFC013A059BB00485DDB /* ia32_defs.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA713A059BB00485DDB /* ia32_defs.h */; };
 		B98ECFC113A059BB00485DDB /* mtrr.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA813A059BB00485DDB /* mtrr.h */; };
 		B98ECFC213A059BB00485DDB /* paging.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFA913A059BB00485DDB /* paging.h */; };
 		B98ECFC313A059BB00485DDB /* segments.h in Headers */ = {isa = PBXBuildFile; fileRef = B98ECFAA13A059BB00485DDB /* segments.h */; };
@@ -147,7 +147,7 @@
 		B98ECFA313A059BB00485DDB /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
 		B98ECFA413A059BB00485DDB /* dump_vmcs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dump_vmcs.h; sourceTree = "<group>"; };
 		B98ECFA513A059BB00485DDB /* hax_driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hax_driver.h; sourceTree = "<group>"; };
-		B98ECFA713A059BB00485DDB /* ia32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ia32.h; sourceTree = "<group>"; };
+		B98ECFA713A059BB00485DDB /* ia32_defs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ia32_defs.h; sourceTree = "<group>"; };
 		B98ECFA813A059BB00485DDB /* mtrr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mtrr.h; sourceTree = "<group>"; };
 		B98ECFA913A059BB00485DDB /* paging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = paging.h; sourceTree = "<group>"; };
 		B98ECFAA13A059BB00485DDB /* segments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = segments.h; sourceTree = "<group>"; };
@@ -291,7 +291,7 @@
 				B98ECFA313A059BB00485DDB /* debug.h */,
 				B98ECFA413A059BB00485DDB /* dump_vmcs.h */,
 				B98ECFA513A059BB00485DDB /* hax_driver.h */,
-				B98ECFA713A059BB00485DDB /* ia32.h */,
+				B98ECFA713A059BB00485DDB /* ia32_defs.h */,
 				B98ECFA813A059BB00485DDB /* mtrr.h */,
 				B98ECFA913A059BB00485DDB /* paging.h */,
 				B98ECFAA13A059BB00485DDB /* segments.h */,
@@ -329,7 +329,7 @@
 				B98ECFBD13A059BB00485DDB /* dump_vmcs.h in Headers */,
 				6456261F1EEFF705005280EF /* ept2.h in Headers */,
 				B98ECFBE13A059BB00485DDB /* hax_driver.h in Headers */,
-				B98ECFC013A059BB00485DDB /* ia32.h in Headers */,
+				B98ECFC013A059BB00485DDB /* ia32_defs.h in Headers */,
 				B98ECFC113A059BB00485DDB /* mtrr.h in Headers */,
 				B98ECFC213A059BB00485DDB /* paging.h in Headers */,
 				CFD697491ED2DCB700F10631 /* memory.h in Headers */,

--- a/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
+++ b/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		64B85BE91EF4D34D00223ABD /* ept2.c in Sources */ = {isa = PBXBuildFile; fileRef = 64B85BE81EF4D34D00223ABD /* ept2.c */; };
 		64BB0CD220F36C470064593A /* vmx_ops.asm in Sources */ = {isa = PBXBuildFile; fileRef = 64BB0CD020F36C470064593A /* vmx_ops.asm */; };
 		64BB0CD320F36C470064593A /* ia32_ops.asm in Sources */ = {isa = PBXBuildFile; fileRef = 64BB0CD120F36C470064593A /* ia32_ops.asm */; };
+		64CD0F582101B51100099B53 /* ia32.h in Headers */ = {isa = PBXBuildFile; fileRef = 64CD0F572101B51100099B53 /* ia32.h */; };
 		6E2DBBCC18EB6125003B66C9 /* page_walker.c in Sources */ = {isa = PBXBuildFile; fileRef = 6E2DBBCB18EB6125003B66C9 /* page_walker.c */; };
 		6E2DBBCE18EB6155003B66C9 /* page_walker.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E2DBBCD18EB6155003B66C9 /* page_walker.h */; };
 		A669096B20F9985300739075 /* ia32.c in Sources */ = {isa = PBXBuildFile; fileRef = A669096A20F9985300739075 /* ia32.c */; };
@@ -135,6 +136,7 @@
 		64B85BE81EF4D34D00223ABD /* ept2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ept2.c; path = ../../../core/ept2.c; sourceTree = "<group>"; };
 		64BB0CD020F36C470064593A /* vmx_ops.asm */ = {isa = PBXFileReference; explicitFileType = sourcecode.nasm; name = vmx_ops.asm; path = ../../../core/vmx_ops.asm; sourceTree = "<group>"; };
 		64BB0CD120F36C470064593A /* ia32_ops.asm */ = {isa = PBXFileReference; explicitFileType = sourcecode.nasm; name = ia32_ops.asm; path = ../../../core/ia32_ops.asm; sourceTree = "<group>"; };
+		64CD0F572101B51100099B53 /* ia32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ia32.h; sourceTree = "<group>"; };
 		6E2DBBCB18EB6125003B66C9 /* page_walker.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = page_walker.c; path = ../../../core/page_walker.c; sourceTree = "<group>"; };
 		6E2DBBCD18EB6155003B66C9 /* page_walker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = page_walker.h; sourceTree = "<group>"; };
 		A669096A20F9985300739075 /* ia32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ia32.c; path = ../../../core/ia32.c; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 		B98ECF9F13A059BB00485DDB /* include */ = {
 			isa = PBXGroup;
 			children = (
+				64CD0F572101B51100099B53 /* ia32.h */,
 				642FD41C20D9F79100C197FF /* emulate_ops.h */,
 				642FD41D20D9F79100C197FF /* emulate.h */,
 				CFD697481ED2DCB700F10631 /* memory.h */,
@@ -337,6 +340,7 @@
 				B98ECFC513A059BB00485DDB /* types.h in Headers */,
 				B98ECFC613A059BB00485DDB /* vcpu.h in Headers */,
 				B98ECFC813A059BB00485DDB /* vm.h in Headers */,
+				64CD0F582101B51100099B53 /* ia32.h in Headers */,
 				B98ECFC913A059BB00485DDB /* vmx.h in Headers */,
 				4324E35613A3781500FA7CFB /* hax_core_interface.h in Headers */,
 				43440D1F13A3834B002E1442 /* hax_interface_mac.h in Headers */,

--- a/include/asm.h
+++ b/include/asm.h
@@ -33,16 +33,8 @@
 
 #include "hax_types.h"
 
-#ifdef _M_IX86
-#define ASMCALL __cdecl
-#else  // !_M_IX86
-#define ASMCALL
-#endif  // _M_IX86
-
 union cpuid_args_t;
-struct vcpu_t;
-struct vcpu_state_t;
-struct invept_desc;
+struct system_desc_t;
 
 mword ASMCALL get_cr0(void);
 mword ASMCALL get_cr2(void);

--- a/include/asm.h
+++ b/include/asm.h
@@ -38,7 +38,7 @@ struct system_desc_t;
 
 mword ASMCALL get_cr0(void);
 mword ASMCALL get_cr2(void);
-uint64 ASMCALL get_cr3(void);
+mword ASMCALL get_cr3(void);
 mword ASMCALL get_cr4(void);
 mword ASMCALL get_dr0(void);
 mword ASMCALL get_dr1(void);

--- a/include/hax.h
+++ b/include/hax.h
@@ -34,7 +34,10 @@
 #include "hax_types.h"
 #include "hax_list.h"
 #include "hax_interface.h"
-#include "asm.h"
+
+// TODO: Refactor proc_event_pending(), and then delete the following forward
+// declaration
+struct vcpu_t;
 
 extern int hax_page_size;
 

--- a/include/hax.h
+++ b/include/hax.h
@@ -244,6 +244,10 @@ extern int cpu_number(void);
 
 uint32_t hax_cpuid(void);
 int proc_event_pending(struct vcpu_t *vcpu);
+
+void hax_disable_preemption(preempt_flag *eflags);
+void hax_enable_preemption(preempt_flag *eflags);
+
 void hax_enable_irq(void);
 void hax_disable_irq(void);
 

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -185,7 +185,6 @@ enum component_index_t {
 
 typedef enum component_index_t component_index_t;
 
-struct system_desc_t;
 #ifdef __MACH__
 #include "darwin/hax_types_mac.h"
 #endif
@@ -201,5 +200,11 @@ typedef uint64 paddr_t;
 typedef uint64 vaddr_t;
 
 extern int32 hax_page_size;
+
+#ifdef _M_IX86
+#define ASMCALL __cdecl
+#else  // !_M_IX86
+#define ASMCALL
+#endif  // _M_IX86
 
 #endif  // HAX_TYPES_H_

--- a/windows/hax_host_mem.c
+++ b/windows/hax_host_mem.c
@@ -29,6 +29,7 @@
  */
 
 #include "../include/hax_host_mem.h"
+#include "../include/hax.h"
 #include "../core/include/paging.h"
 
 int hax_pin_user_pages(uint64 start_uva, uint64 size, hax_memdesc_user *memdesc)

--- a/windows/hax_wrapper.c
+++ b/windows/hax_wrapper.c
@@ -29,6 +29,7 @@
  */
 
 #include "hax_win.h"
+#include "../core/include/ia32.h"
 
 int default_hax_log_level = 3;
 int max_cpus;
@@ -224,6 +225,16 @@ void hax_enable_preemption(preempt_flag *flags)
     if (*flags >= DISPATCH_LEVEL)
         return;
     KeLowerIrql(*flags);
+}
+
+void hax_enable_irq(void)
+{
+    asm_enable_irq();
+}
+
+void hax_disable_irq(void)
+{
+    asm_disable_irq();
 }
 
 void hax_error(char *fmt, ...)


### PR DESCRIPTION
One would expect the functions implemented in `core/ia32_ops.asm` and `core/ia32.c` to be declared in `core/include/ia32.h`, but that's not the case. Same can be said for `core/vmx_ops.asm`, `core/vmx.c` and `core/include/vmx.h`. This PR fixes both.

BTW, I try to follow [these guidelines](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes) when modifying `#include` statements.