### PR TITLE
core: save/restore FPU registers in VM entry/exit

### DIFF
--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -178,7 +178,6 @@ struct vcpu_t {
         uint64 paused                          : 1;
         uint64 panicked                        : 1;
         uint64 is_running                      : 1;
-        uint64 is_fpu_used                     : 1;
         uint64 is_vmcs_loaded                  : 1;
         uint64 event_injected                  : 1;
         /* vcpu->state is valid or not */
@@ -190,7 +189,7 @@ struct vcpu_t {
         uint64 vmcs_pending_entry_instr_length : 1;
         uint64 vmcs_pending_entry_intr_info    : 1;
         uint64 vmcs_pending_guest_cr3          : 1;
-        uint64 padding                         : 52;
+        uint64 padding                         : 53;
     };
 
     /* For TSC offseting feature*/


### PR DESCRIPTION
Guest OS kernel/app might use SSE instruction and registers.
When Guest OS VM exits, these registers should be saved, or else
it might be corrupted by host OS/app. In next time guest VM
enter, guest's SSE registers context might be corrupted.

Guest app segfault and kernel panic were reported
which should be related with this issue.

This change is to remove is_fpu_used flag so guest FPU registers
could be saved in VM exit and restored in VM entry unconditionally.

Fixes #39, fixes #74.