### PR TITLE
darwin: fix Debug build and install issue

### DIFF
--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -114,7 +114,8 @@ typedef union PW_PFEC_U {
 
 uint32 pw_reserved_bits_high_mask;
 
-inline uint64 pw_retrieve_table_from_cr3(uint64 cr3, bool is_pae, bool is_lme)
+static inline uint64 pw_retrieve_table_from_cr3(uint64 cr3, bool is_pae,
+                                                bool is_lme)
 {
     if (!is_pae || is_lme)
         return ALIGN_BACKWARD(cr3, PAGE_SIZE_4K);
@@ -215,7 +216,7 @@ static bool pw_is_big_page_pde(PW_PAGE_ENTRY *entry, bool is_lme, bool is_pae,
     return is_pse;
 }
 
-inline bool pw_is_1gb_page_pdpte(PW_PAGE_ENTRY *entry)
+static inline bool pw_is_1gb_page_pdpte(PW_PAGE_ENTRY *entry)
 {
     return entry->pae_lme_entry.bits._page_size;
 }

--- a/include/darwin/hax_types_mac.h
+++ b/include/darwin/hax_types_mac.h
@@ -148,7 +148,7 @@ typedef mword preempt_flag;
 typedef uint64_t cpumap_t;
 typedef uint64_t HAX_VADDR_T;
 
-inline cpumap_t cpu2cpumap(int cpu)
+static inline cpumap_t cpu2cpumap(int cpu)
 {
     return (0x1UL << cpu);
 }


### PR DESCRIPTION
In Mac, when install Debug version haxm driver, it reports several
function symbols missing. They are inline function.

Mac Debug build uses "-O0" for build optimazation. With this flag,
some inline functions which don't have static prefix have build
issue, they don't perform inline expansion.

This change is to add static prefix to several inline functions.

Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>