### PR TITLE
darwin: Make Debug default build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ The `Release` configuration does not do that.
 1. `cd X:\path\to\haxm\`
 1. `X:\path\to\nuget.exe restore`
 1. `msbuild HaxmDriver.sln /p:Configuration="Debug" /p:Platform="x64"`
-   * Use `Release` instead of `Debug` to build a faster driver without
-a digital signature.
+   * Use `Release` instead of `Debug` to build an optimized driver that is
+suitable for release. Note that the `Release` configuration does not sign the
+driver with a test certificate.
    * Use `Win32` instead of `x64` to build a 32-bit driver that works on 32-bit
 Windows.
    * Add `/t:rebuild` for a clean rebuild instead of an incremental build.
@@ -67,12 +68,14 @@ If successful, the driver binary (`IntelHaxm.sys`) will be generated in
 ### Build steps
 1. `cd /path/to/haxm/`
 1. `cd darwin/hax_driver/com_intel_hax/`
-1. `xcodebuild -config Release`
+1. `xcodebuild -configuration Debug`
    * Use `-sdk` to override the default macOS SDK version (10.10), e.g.
 `-sdk macosx10.12`.
+   * Use `Release` instead of `Debug` to build an optimized KEXT that is
+suitable for release.
 
 If successful, the kext (`intelhaxm.kext/`) will be generated in
-`/path/to/haxm/darwin/hax_driver/com_intel_hax/build/Release/`.
+`/path/to/haxm/darwin/hax_driver/com_intel_hax/build/Debug/`.
 
 ## Reporting an Issue
 You are welcome to file a GitHub issue if you discover a general HAXM bug or

--- a/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
+++ b/darwin/hax_driver/com_intel_hax/intelhaxm.xcodeproj/project.pbxproj
@@ -575,7 +575,7 @@
 				1DEB91C508733DAC0010E9CD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		1DEB91C708733DAC0010E9CD /* Build configuration list for PBXProject "intelhaxm" */ = {
 			isa = XCConfigurationList;
@@ -584,7 +584,7 @@
 				1DEB91C908733DAC0010E9CD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Now that the "Debug" Xcode build configuration is fixed, make it
the default, because it is suitable for day-to-day development.
Update the README document accordingly.

Signed-off-by: Yu Ning <yu.ning@intel.com>