### PR TITLE
Refine is_fpu_used logic to handle eager fpu.

### DIFF
--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -178,6 +178,7 @@ struct vcpu_t {
         uint64 paused                          : 1;
         uint64 panicked                        : 1;
         uint64 is_running                      : 1;
+        uint64 is_fpu_used                     : 1;
         uint64 is_vmcs_loaded                  : 1;
         uint64 event_injected                  : 1;
         /* vcpu->state is valid or not */
@@ -189,7 +190,8 @@ struct vcpu_t {
         uint64 vmcs_pending_entry_instr_length : 1;
         uint64 vmcs_pending_entry_intr_info    : 1;
         uint64 vmcs_pending_guest_cr3          : 1;
-        uint64 padding                         : 53;
+        uint64 is_ts_set_by_haxm               : 1;
+        uint64 padding                         : 51;
     };
 
     /* For TSC offseting feature*/


### PR DESCRIPTION
Hi, Ning,

This refines detection of guest fpu usage. Old haxm seems to rely on guest setting CR0.TS and trapping exception 7.
I know there is a patch for forcefully turning on fpu save/restore. I do not have any preference to either solution. I just uploaded mine in case you want a friendly version towards non-fpu usage guests.

Haitao