### PR TITLE
Fix TEST instruction emulation

### DIFF
--- a/core/emulate.c
+++ b/core/emulate.c
@@ -197,7 +197,8 @@ static const struct em_opcode_t opcode_table[256] = {
     G(opcode_group1, op_modrm_rm, op_simm, op_none, 0),
     G(opcode_group1, op_modrm_rm, op_simm, op_none, INSN_BYTEOP),
     G(opcode_group1, op_modrm_rm, op_simm8, op_none, 0),
-    X4(N),
+    F2_BV(em_test, op_modrm_rm, op_modrm_reg, op_none, INSN_MODRM),
+    X2(N),  /* TODO: 0x86 & 0x87 (XCHG) */
     I2_BV(em_mov, op_modrm_rm, op_modrm_reg, op_none, INSN_MODRM | INSN_MOV),
     I2_BV(em_mov, op_modrm_reg, op_modrm_rm, op_none, INSN_MODRM | INSN_MOV),
     X4(N),

--- a/tests/test_emulator.cpp
+++ b/tests/test_emulator.cpp
@@ -280,7 +280,8 @@ protected:
 
     template <int N>
     void test_insn_rN_rN(const char* insn_name,
-                         const std::vector<test_alu_2op_t>& tests) {
+                         const std::vector<test_alu_2op_t>& tests,
+                         bool readonly_dst = false) {
         char insn[256];
         test_cpu_t vcpu_original;
         test_cpu_t vcpu_expected;
@@ -294,7 +295,8 @@ protected:
             vcpu_original.gpr[REG_RCX] = test.in_src;
             vcpu_original.flags = test.in_flags;
             vcpu_expected = vcpu_original;
-            vcpu_expected.gpr[REG_RDX] = test.out_dst;
+            if (!readonly_dst)
+                vcpu_expected.gpr[REG_RDX] = test.out_dst;
             vcpu_expected.flags = test.out_flags;
             run(insn, vcpu_original, vcpu_expected);
         }
@@ -302,7 +304,8 @@ protected:
 
     template <int N>
     void test_insn_rN_iN(const char* insn_name,
-                         const std::vector<test_alu_2op_t>& tests) {
+                         const std::vector<test_alu_2op_t>& tests,
+                         bool readonly_dst = false) {
         char insn[256];
         test_cpu_t vcpu_original;
         test_cpu_t vcpu_expected;
@@ -315,7 +318,8 @@ protected:
             vcpu_original.gpr[REG_RAX] = test.in_dst;
             vcpu_original.flags = test.in_flags;
             vcpu_expected = vcpu_original;
-            vcpu_expected.gpr[REG_RAX] = test.out_dst;
+            if (!readonly_dst)
+                vcpu_expected.gpr[REG_RAX] = test.out_dst;
             vcpu_expected.flags = test.out_flags;
             run(insn, vcpu_original, vcpu_expected);
         }
@@ -323,7 +327,8 @@ protected:
 
     template <int N>
     void test_insn_mN_iN(const char* insn_name,
-                         const std::vector<test_alu_2op_t>& tests) {
+                         const std::vector<test_alu_2op_t>& tests,
+                         bool readonly_dst = false) {
         char insn[256];
         test_cpu_t vcpu_original;
         test_cpu_t vcpu_expected;
@@ -338,7 +343,8 @@ protected:
             (uint64_t&)vcpu_original.mem[0x40] = test.in_dst;
             vcpu_original.flags = test.in_flags;
             vcpu_expected = vcpu_original;
-            (uint64_t&)vcpu_expected.mem[0x40] = test.out_dst;
+            if (!readonly_dst)
+                (uint64_t&)vcpu_expected.mem[0x40] = test.out_dst;
             vcpu_expected.flags = test.out_flags;
             run(insn, vcpu_original, vcpu_expected);
         }
@@ -346,7 +352,8 @@ protected:
 
     template <int N>
     void test_insn_rN_mN(const char* insn_name,
-                         const std::vector<test_alu_2op_t>& tests) {
+                         const std::vector<test_alu_2op_t>& tests,
+                         bool readonly_dst = false) {
         char insn[256];
         test_cpu_t vcpu_original;
         test_cpu_t vcpu_expected;
@@ -362,7 +369,8 @@ protected:
             vcpu_original.gpr[REG_RAX] = test.in_dst;
             vcpu_original.flags = test.in_flags;
             vcpu_expected = vcpu_original;
-            vcpu_expected.gpr[REG_RAX] = test.out_dst;
+            if (!readonly_dst)
+                vcpu_expected.gpr[REG_RAX] = test.out_dst;
             vcpu_expected.flags = test.out_flags;
             run(insn, vcpu_original, vcpu_expected);
         }
@@ -370,7 +378,8 @@ protected:
 
     template <int N>
     void test_insn_mN_rN(const char* insn_name,
-                         const std::vector<test_alu_2op_t>& tests) {
+                         const std::vector<test_alu_2op_t>& tests,
+                         bool readonly_dst = false) {
         char insn[256];
         test_cpu_t vcpu_original;
         test_cpu_t vcpu_expected;
@@ -386,7 +395,8 @@ protected:
             (uint64_t&)vcpu_original.mem[0x40] = test.in_dst;
             vcpu_original.flags = test.in_flags;
             vcpu_expected = vcpu_original;
-            (uint64_t&)vcpu_expected.mem[0x40] = test.out_dst;
+            if (!readonly_dst)
+                (uint64_t&)vcpu_expected.mem[0x40] = test.out_dst;
             vcpu_expected.flags = test.out_flags;
             run(insn, vcpu_original, vcpu_expected);
         }
@@ -471,17 +481,29 @@ protected:
         if (N == 64 && sizeof(void*) < 8) {
             return;
         }
-        test_insn_rN_rN<N>(insn_name, tests);
-        test_insn_rN_iN<N>(insn_name, tests);
-        test_insn_mN_iN<N>(insn_name, tests);
-        test_insn_rN_mN<N>(insn_name, tests);
-        test_insn_mN_rN<N>(insn_name, tests);
+        test_insn_rN_rN<N>(insn_name, tests, false);
+        test_insn_rN_iN<N>(insn_name, tests, false);
+        test_insn_mN_iN<N>(insn_name, tests, false);
+        test_insn_rN_mN<N>(insn_name, tests, false);
+        test_insn_mN_rN<N>(insn_name, tests, false);
+    }
+
+    template <int N>
+    void test_test(const std::vector<test_alu_2op_t>& tests) {
+        if (N == 64 && sizeof(void*) < 8) {
+            return;
+        }
+        // TEST is similar to AND, except that:
+        // a) The destination operand is read-only.
+        // b) Not all operand combinations are possible/implemented.
+        test_insn_mN_iN<N>("test", tests, true);
+        test_insn_mN_rN<N>("test", tests, true);
     }
 };
 
 TEST_F(EmulatorTest, insn_unimpl_primary) {
-    // Opcode 0x85 (TEST r/mN, rN) is unimplemented
-    test_insn_unimpl("test dword ptr [edx + 2*ecx + 0x10], esi");
+    // Opcode 0x87 (XCHG r/mN, rN) is unimplemented
+    test_insn_unimpl("xchg dword ptr [edx + 2*ecx + 0x10], esi");
 }
 
 TEST_F(EmulatorTest, insn_unimpl_secondary) {
@@ -536,6 +558,29 @@ TEST_F(EmulatorTest, insn_and) {
     test_alu_2op<64>("and", {
         { 0x0000FFFF'F0F0FFFFULL, 0xFFFFFFFF'FFFF0000ULL, 0,
           0x0000FFFF'F0F00000ULL, RFLAGS_PF },
+    });
+}
+
+TEST_F(EmulatorTest, insn_test) {
+    test_test<8>({
+        { 0x55, 0xF0, RFLAGS_CF,
+          0x50, RFLAGS_PF },
+        { 0xF0, 0x0F, RFLAGS_OF,
+          0x00, RFLAGS_PF | RFLAGS_ZF },
+    });
+    test_test<16>({
+        { 0x0001, 0xF00F, RFLAGS_CF | RFLAGS_OF,
+          0x0001, 0 },
+        { 0xFF00, 0xF0F0, 0,
+          0xF000, RFLAGS_PF | RFLAGS_SF },
+    });
+    test_test<32>({
+        { 0xFFFF0001, 0xFFFF0001, 0,
+          0xFFFF0001, RFLAGS_SF },
+    });
+    test_test<64>({
+        { 0x0000FFFF'F0F0FFFFULL, 0xFFFF0000'0F0F0000ULL, 0,
+          0x00000000'00000000ULL, RFLAGS_PF | RFLAGS_ZF },
     });
 }
 


### PR DESCRIPTION
This PR fixes two issues with the instruction emulator:

1. Many unsupported MMIO instructions (e.g. `TEST r/mN, rN`, `XCHG r/mN, rN`, etc.) lead to a host crash.
2. `TEST r/mN, rN` is not supported.