### PR TITLE
HaxmLoader: Show version number in usage

### DIFF
--- a/HaxmLoader/haxm_loader.c
+++ b/HaxmLoader/haxm_loader.c
@@ -173,6 +173,7 @@ cleanup:
 
 static void PrintUsage(void)
 {
+    printf("HaxmLoader version 1.0.0\r\n");
     printf("Usage: HaxmLoader [mode]\r\n");
     printf("  Modes:\r\n");
     printf("    -i <sys_file_path>: install driver"


### PR DESCRIPTION
Use version 1.0.0 for the first release of HaxmLoader.

Signed-off-by: Yu Ning <yu.ning@intel.com>