### PR TITLE
Codebase cleanup and portability refactoring

### DIFF
--- a/core/chunk.c
+++ b/core/chunk.c
@@ -33,7 +33,7 @@
 #include "../include/hax_host_mem.h"
 #include "include/paging.h"
 
-int chunk_alloc(uint64 base_uva, uint64 size, hax_chunk **chunk)
+int chunk_alloc(uint64_t base_uva, uint64_t size, hax_chunk **chunk)
 {
     hax_chunk *chk;
     int ret;

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -47,7 +47,7 @@ static void cpu_vmentry_failed(struct vcpu_t *vcpu, vmx_result_t result);
 static int cpu_vmexit_handler(struct vcpu_t *vcpu, exit_reason_t exit_reason,
                               struct hax_tunnel *htun);
 
-static int cpu_emt64_enable()
+static int cpu_emt64_enable(void)
 {
     uint32 effer;
 
@@ -55,7 +55,7 @@ static int cpu_emt64_enable()
     return effer & 0x400;
 }
 
-static int cpu_nx_enable()
+static int cpu_nx_enable(void)
 {
     uint32 effer;
 
@@ -71,7 +71,7 @@ bool cpu_has_feature(uint32_t feature)
     return cpuid_host_has_feature(&cache, feature);
 }
 
-void cpu_init_feature_cache()
+void cpu_init_feature_cache(void)
 {
     cpuid_host_init(&cache);
 }

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -49,18 +49,18 @@ static int cpu_vmexit_handler(struct vcpu_t *vcpu, exit_reason_t exit_reason,
 
 static int cpu_emt64_enable(void)
 {
-    uint32_t effer;
+    uint32_t efer;
 
-    effer = ia32_rdmsr(IA32_EFER);
-    return effer & 0x400;
+    efer = ia32_rdmsr(IA32_EFER);
+    return efer & 0x400;
 }
 
 static int cpu_nx_enable(void)
 {
-    uint32_t effer;
+    uint32_t efer;
 
-    effer = ia32_rdmsr(IA32_EFER);
-    return effer & 0x800;
+    efer = ia32_rdmsr(IA32_EFER);
+    return efer & 0x800;
 }
 
 bool cpu_has_feature(uint32_t feature)

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -728,7 +728,7 @@ vmx_result_t cpu_vmxroot_leave(void)
         }
     } else {
         log_vmxoff_no = 1;
-#ifdef __MACH__
+#ifdef HAX_PLATFORM_DARWIN
         hax_debug("Skipping VMXOFF because another VMM (VirtualBox or macOS"
                   " Hypervisor Framework) is running\n");
 #else
@@ -791,7 +791,7 @@ vmx_result_t cpu_vmxroot_enter(void)
     } else {
         bool fatal = true;
 
-#ifdef __MACH__
+#ifdef HAX_PLATFORM_DARWIN
         if ((result == VMX_FAIL_INVALID) && cpu_data->host_cr4_vmxe) {
             // On macOS, if VMXON fails with VMX_FAIL_INVALID and host CR4.VMXE
             // was already set, it is very likely that another VMM (VirtualBox

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -49,7 +49,7 @@ static int cpu_vmexit_handler(struct vcpu_t *vcpu, exit_reason_t exit_reason,
 
 static int cpu_emt64_enable(void)
 {
-    uint32 effer;
+    uint32_t effer;
 
     effer = ia32_rdmsr(IA32_EFER);
     return effer & 0x400;
@@ -57,7 +57,7 @@ static int cpu_emt64_enable(void)
 
 static int cpu_nx_enable(void)
 {
-    uint32 effer;
+    uint32_t effer;
 
     effer = ia32_rdmsr(IA32_EFER);
     return effer & 0x800;
@@ -80,7 +80,7 @@ void cpu_init_vmx(void *arg)
 {
     struct info_t vmx_info;
     struct per_cpu_data *cpu_data;
-    uint32 fc_msr;
+    uint32_t fc_msr;
     vmcs_t *vmxon;
     int nx_enable = 0, vt_enable = 0;
 
@@ -162,7 +162,7 @@ void cpu_init_vmx(void *arg)
     if (vmx_info._vmcs_region_length > PAGE_SIZE)
         hax_log("HAX: VMCS of %d bytes not supported by this Hypervisor. "
                 "Max supported %u bytes\n",
-                vmx_info._vmcs_region_length, (uint32)PAGE_SIZE);
+                vmx_info._vmcs_region_length, (uint32_t)PAGE_SIZE);
     vmxon = (vmcs_t *)hax_page_va(cpu_data->vmxon_page);
     vmxon->_revision_id = vmx_info._vmcs_revision_id;
 
@@ -283,7 +283,7 @@ static int cpu_vmexit_handler(struct vcpu_t *vcpu, exit_reason_t exit_reason,
     return ret;
 }
 /*Remove this function. It only for debug*/
-/*void dump_cs_ds(uint16 cs, uint16 ds)
+/*void dump_cs_ds(uint16_t cs, uint16_t ds)
 {
     struct system_desc_t desc;
     struct seg_desc_t *seg_desc;
@@ -405,7 +405,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     int ret;
     preempt_flag flags;
     struct vcpu_state_t *state = vcpu->state;
-    uint32 vmcs_err = 0;
+    uint32_t vmcs_err = 0;
 
     while (1) {
         exit_reason_t exit_reason;
@@ -431,7 +431,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
          * values by vmx hardware.
          */
         {
-            uint32 temp= vmread(vcpu, GUEST_CS_AR);
+            uint32_t temp= vmread(vcpu, GUEST_CS_AR);
 
             if( (temp & 0xf) == 0xa) {
                 temp = temp +1;
@@ -442,7 +442,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
          * let's hard-code it for now
          */
         {
-            uint32 temp = vmread(vcpu, GUEST_TR_AR);
+            uint32_t temp = vmread(vcpu, GUEST_TR_AR);
 
             temp = (temp & ~0xf) | 0xb;
             vmwrite(vcpu, GUEST_TR_AR, temp);
@@ -508,7 +508,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     }
 }
 
-uint8 is_vmcs_loaded(struct vcpu_t *vcpu)
+uint8_t is_vmcs_loaded(struct vcpu_t *vcpu)
 {
     return (vcpu && vcpu->is_vmcs_loaded);
 }
@@ -517,16 +517,16 @@ int debug_vmcs_count = 0;
 
 void restore_host_cr4_vmxe(struct per_cpu_data *cpu_data);
 
-uint32 log_host_cr4_vmxe = 0;
-uint64 log_host_cr4 = 0;
+uint32_t log_host_cr4_vmxe = 0;
+uint64_t log_host_cr4 = 0;
 vmx_result_t log_vmxon_res = 0;
-uint64 log_vmxon_addr = 0;
-uint32 log_vmxon_err_type1 = 0;
-uint32 log_vmxon_err_type2 = 0;
-uint32 log_vmxon_err_type3 = 0;
-uint32 log_vmclear_err = 0;
-uint32 log_vmptrld_err = 0;
-uint32 log_vmxoff_no = 0;
+uint64_t log_vmxon_addr = 0;
+uint32_t log_vmxon_err_type1 = 0;
+uint32_t log_vmxon_err_type2 = 0;
+uint32_t log_vmxon_err_type3 = 0;
+uint32_t log_vmclear_err = 0;
+uint32_t log_vmptrld_err = 0;
+uint32_t log_vmxoff_no = 0;
 vmx_result_t log_vmxoff_res = 0;
 
 void hax_clear_panic_log(struct vcpu_t *vcpu)
@@ -561,7 +561,7 @@ void hax_panic_log(struct vcpu_t *vcpu)
     hax_error("log_vmxoff_res %x\n", log_vmxoff_res);
 }
 
-uint32 load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags)
+uint32_t load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags)
 {
     struct per_cpu_data *cpu_data;
     paddr_t vmcs_phy;
@@ -628,7 +628,7 @@ void restore_host_cr4_vmxe(struct per_cpu_data *cpu_data)
     }
 }
 
-uint32 put_vmcs(struct vcpu_t *vcpu, preempt_flag *flags)
+uint32_t put_vmcs(struct vcpu_t *vcpu, preempt_flag *flags)
 {
     struct per_cpu_data *cpu_data = current_cpu_data();
     paddr_t vmcs_phy;
@@ -745,7 +745,7 @@ vmx_result_t cpu_vmxroot_leave(void)
 vmx_result_t cpu_vmxroot_enter(void)
 {
     struct per_cpu_data *cpu_data = current_cpu_data();
-    uint64 fc_msr;
+    uint64_t fc_msr;
     paddr_t vmxon_addr;
     vmx_result_t result = VMX_SUCCEED;
 
@@ -816,8 +816,8 @@ vmx_result_t cpu_vmxroot_enter(void)
 
         if (fatal) {
             hax_error("VMXON failed for region 0x%llx (result=0x%x, vmxe=%x)\n",
-                      hax_page_pa(cpu_data->vmxon_page), (uint32)result,
-                      (uint32)cpu_data->host_cr4_vmxe);
+                      hax_page_pa(cpu_data->vmxon_page), (uint32_t)result,
+                      (uint32_t)cpu_data->host_cr4_vmxe);
             restore_host_cr4_vmxe(cpu_data);
             if (result == VMX_FAIL_INVALID) {
                 log_vmxon_err_type1 = 1;

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -159,10 +159,10 @@ void cpu_init_vmx(void *arg)
     }
 #endif
 
-    if (vmx_info._vmcs_region_length > PAGE_SIZE)
+    if (vmx_info._vmcs_region_length > HAX_PAGE_SIZE)
         hax_log("HAX: VMCS of %d bytes not supported by this Hypervisor. "
                 "Max supported %u bytes\n",
-                vmx_info._vmcs_region_length, (uint32_t)PAGE_SIZE);
+                vmx_info._vmcs_region_length, (uint32_t)HAX_PAGE_SIZE);
     vmxon = (vmcs_t *)hax_page_va(cpu_data->vmxon_page);
     vmxon->_revision_id = vmx_info._vmcs_revision_id;
 

--- a/core/dump_vmcs.c
+++ b/core/dump_vmcs.c
@@ -34,9 +34,9 @@
 #include "../include/hax.h"
 
 extern unsigned char **vmcs_names;
-extern uint32 vmcs_hash(uint32 enc);
+extern uint32_t vmcs_hash(uint32_t enc);
 
-static uint32 dump_vmcs_list[] = {
+static uint32_t dump_vmcs_list[] = {
     VMX_PIN_CONTROLS,
     VMX_PRIMARY_PROCESSOR_CONTROLS,
     VMX_SECONDARY_PROCESSOR_CONTROLS,
@@ -180,7 +180,7 @@ static uint32 dump_vmcs_list[] = {
     GUEST_ACTIVITY_STATE,
 };
 
-static int encode_type(uint32 encode)
+static int encode_type(uint32_t encode)
 {
     return (encode >> 13) & 0x3;
 }
@@ -198,10 +198,10 @@ unsigned char *get_vmcsname_entry(int num)
 
 void dump_vmcs(struct vcpu_t *vcpu)
 {
-    uint32 i, enc, n;
+    uint32_t i, enc, n;
     unsigned char *name;
 
-    uint32 *list = dump_vmcs_list;
+    uint32_t *list = dump_vmcs_list;
     n = ARRAY_ELEMENTS(dump_vmcs_list);
 
     for (i = 0; i < n; i++) {

--- a/core/emulate.c
+++ b/core/emulate.c
@@ -288,7 +288,7 @@ static bool is_translation_required(struct em_context_t *ctxt)
 static uint64_t get_canonical_address(struct em_context_t *ctxt,
                                       uint64_t addr, uint vaddr_bits)
 {
-    return ((int64)addr << (64 - vaddr_bits)) >> (64 - vaddr_bits);
+    return ((int64_t)addr << (64 - vaddr_bits)) >> (64 - vaddr_bits);
 }
 
 static em_status_t get_linear_address(struct em_context_t *ctxt,
@@ -475,24 +475,24 @@ static uint64_t insn_fetch_u64(struct em_context_t *ctxt)
     return result;
 }
 
-static int8 insn_fetch_s8(struct em_context_t *ctxt)
+static int8_t insn_fetch_s8(struct em_context_t *ctxt)
 {
-    return (int8)insn_fetch_u8(ctxt);
+    return (int8_t)insn_fetch_u8(ctxt);
 }
 
-static int16 insn_fetch_s16(struct em_context_t *ctxt)
+static int16_t insn_fetch_s16(struct em_context_t *ctxt)
 {
-    return (int16)insn_fetch_u16(ctxt);
+    return (int16_t)insn_fetch_u16(ctxt);
 }
 
-static int32 insn_fetch_s32(struct em_context_t *ctxt)
+static int32_t insn_fetch_s32(struct em_context_t *ctxt)
 {
-    return (int32)insn_fetch_u32(ctxt);
+    return (int32_t)insn_fetch_u32(ctxt);
 }
 
-static int64 insn_fetch_s64(struct em_context_t *ctxt)
+static int64_t insn_fetch_s64(struct em_context_t *ctxt)
 {
-    return (int64)insn_fetch_u64(ctxt);
+    return (int64_t)insn_fetch_u64(ctxt);
 }
 
 static void decode_prefixes(struct em_context_t *ctxt)
@@ -774,7 +774,7 @@ static em_status_t decode_op_simm8(em_context_t *ctxt,
 {
     op->type = OP_IMM;
     op->size = 1;
-    op->value = (int64)(insn_fetch_s8(ctxt));
+    op->value = (int64_t)(insn_fetch_s8(ctxt));
     return EM_CONTINUE;
 }
 

--- a/core/ept.c
+++ b/core/ept.c
@@ -43,11 +43,11 @@
 #include "include/paging.h"
 #include "include/vtlb.h"
 
-static uint64 ept_capabilities;
+static uint64_t ept_capabilities;
 
 #define EPT_BASIC_CAPS  (ept_cap_WB | ept_cap_invept_ac)
 
-bool ept_set_caps(uint64 caps)
+bool ept_set_caps(uint64_t caps)
 {
     if ((caps & EPT_BASIC_CAPS) != EPT_BASIC_CAPS) {
         hax_warning("Broken host EPT support detected (caps=0x%llx)\n", caps);
@@ -68,11 +68,11 @@ bool ept_set_caps(uint64 caps)
     return 1;
 }
 
-static bool ept_has_cap(uint64 cap)
+static bool ept_has_cap(uint64_t cap)
 {
     assert(ept_capabilities != 0);
-    // Avoid implicit conversion from uint64 to bool, because the latter may be
-    // typedef'ed as uint8 (see hax_types_windows.h)
+    // Avoid implicit conversion from uint64_t to bool, because the latter may be
+    // typedef'ed as uint8_t (see hax_types_windows.h)
     return (ept_capabilities & cap) != 0;
 }
 
@@ -82,7 +82,7 @@ static epte_t * ept_get_pde(struct hax_ept *ept, paddr_t gpa)
     epte_t *e;
     uint which_g = gpa >> 30;
     // PML4 and PDPTE level needs 2 pages
-    uint64 offset = (2 + which_g) * PAGE_SIZE_4K;
+    uint64_t offset = (2 + which_g) * PAGE_SIZE_4K;
     // Need Xiantao's check
     unsigned char *ept_addr = hax_page_va(ept->ept_root_page);
 
@@ -342,11 +342,11 @@ static void invept_smpfunc(struct invept_bundle *bundle)
 
 void invept(hax_vm_t *hax_vm, uint type)
 {
-    uint64 eptp_value = vm_get_eptp(hax_vm);
+    uint64_t eptp_value = vm_get_eptp(hax_vm);
     struct invept_desc desc = { eptp_value, 0 };
     struct invept_bundle bundle;
     int cpu_id;
-    uint32 res;
+    uint32_t res;
 
     if (!ept_has_cap(ept_cap_invept)) {
         hax_warning("INVEPT was not called due to missing host support"
@@ -394,17 +394,17 @@ void invept(hax_vm_t *hax_vm, uint type)
             continue;
         }
 
-        res = (uint32)cpu_data->vmxon_res;
+        res = (uint32_t)cpu_data->vmxon_res;
         if (res != VMX_SUCCEED) {
             hax_error("[Processor #%d] INVEPT was not called, because VMXON"
                       " failed (err=0x%x)\n", cpu_id, res);
         } else {
-            res = (uint32)cpu_data->invept_res;
+            res = (uint32_t)cpu_data->invept_res;
             if (res != VMX_SUCCEED) {
                 hax_error("[Processor #%d] INVEPT failed (err=0x%x)\n", cpu_id,
                           res);
             }
-            res = (uint32)cpu_data->vmxoff_res;
+            res = (uint32_t)cpu_data->vmxoff_res;
             if (res != VMX_SUCCEED) {
                 hax_error("[Processor #%d] INVEPT was called, but VMXOFF failed"
                           " (err=0x%x)\n", cpu_id, res);
@@ -413,7 +413,7 @@ void invept(hax_vm_t *hax_vm, uint type)
     }
 }
 
-uint64 vcpu_get_eptp(struct vcpu_t *vcpu)
+uint64_t vcpu_get_eptp(struct vcpu_t *vcpu)
 {
     struct hax_ept *ept = vcpu->vm->ept;
 

--- a/core/ept.c
+++ b/core/ept.c
@@ -62,7 +62,7 @@ bool ept_set_caps(uint64 caps)
     }
 
     caps &= ~EPT_UNSUPPORTED_FEATURES;
-    ASSERT(!ept_capabilities || caps == ept_capabilities);
+    assert(!ept_capabilities || caps == ept_capabilities);
     // FIXME: This assignment is done by all logical processors simultaneously
     ept_capabilities = caps;
     return 1;
@@ -70,7 +70,7 @@ bool ept_set_caps(uint64 caps)
 
 static bool ept_has_cap(uint64 cap)
 {
-    ASSERT(ept_capabilities != 0);
+    assert(ept_capabilities != 0);
     // Avoid implicit conversion from uint64 to bool, because the latter may be
     // typedef'ed as uint8 (see hax_types_windows.h)
     return (ept_capabilities & cap) != 0;
@@ -185,7 +185,7 @@ static bool ept_lookup(struct vcpu_t *vcpu, paddr_t gpa, paddr_t *hpa)
     struct hax_ept *ept = vcpu->vm->ept;
     uint which_g = gpa >> 30;
 
-    ASSERT(ept->ept_root_page);
+    assert(ept->ept_root_page);
     if (which_g >= EPT_MAX_MEM_G) {
         hax_debug("ept_lookup error!\n");
         return 0;
@@ -224,7 +224,7 @@ static bool ept_lookup(struct vcpu_t *vcpu, paddr_t gpa, paddr_t *hpa)
 // TODO: Do we need to consider cross-page case ??
 bool ept_translate(struct vcpu_t *vcpu, paddr_t gpa, uint order, paddr_t *hpa)
 {
-    ASSERT(order == PG_ORDER_4K);
+    assert(order == PG_ORDER_4K);
     return ept_lookup(vcpu, gpa, hpa);
 }
 
@@ -301,7 +301,7 @@ void ept_free (hax_vm_t *hax_vm)
     struct hax_page *page, *n;
     struct hax_ept *ept = hax_vm->ept;
 
-    ASSERT(ept);
+    assert(ept);
 
     if (!ept->ept_root_page)
         return;

--- a/core/ept2.c
+++ b/core/ept2.c
@@ -35,8 +35,8 @@
 #include "../include/hax_host_mem.h"
 
 void ept_handle_mapping_removed(hax_gpa_space_listener *listener,
-                                uint64 start_gfn, uint64 npages, uint64 uva,
-                                uint8 flags)
+                                uint64_t start_gfn, uint64_t npages, uint64_t uva,
+                                uint8_t flags)
 {
     bool is_rom = flags & HAX_MEMSLOT_READONLY;
     hax_ept_tree *tree;
@@ -51,9 +51,9 @@ void ept_handle_mapping_removed(hax_gpa_space_listener *listener,
 }
 
 void ept_handle_mapping_changed(hax_gpa_space_listener *listener,
-                                uint64 start_gfn, uint64 npages,
-                                uint64 old_uva, uint8 old_flags,
-                                uint64 new_uva, uint8 new_flags)
+                                uint64_t start_gfn, uint64_t npages,
+                                uint64_t old_uva, uint8_t old_flags,
+                                uint64_t new_uva, uint8_t new_flags)
 {
     bool was_rom = old_flags & HAX_MEMSLOT_READONLY;
     bool is_rom = new_flags & HAX_MEMSLOT_READONLY;
@@ -70,18 +70,18 @@ void ept_handle_mapping_changed(hax_gpa_space_listener *listener,
 }
 
 int ept_handle_access_violation(hax_gpa_space *gpa_space, hax_ept_tree *tree,
-                                exit_qualification_t qual, uint64 gpa,
-                                uint64 *fault_gfn)
+                                exit_qualification_t qual, uint64_t gpa,
+                                uint64_t *fault_gfn)
 {
     uint combined_perm;
-    uint64 gfn;
+    uint64_t gfn;
     hax_memslot *slot;
     bool is_rom;
     hax_ramblock *block;
     hax_chunk *chunk;
-    uint64 offset_within_slot, offset_within_block, offset_within_chunk;
-    uint64 chunk_offset_low, chunk_offset_high, slot_offset_high;
-    uint64 start_gpa, size;
+    uint64_t offset_within_slot, offset_within_block, offset_within_chunk;
+    uint64_t chunk_offset_low, chunk_offset_high, slot_offset_high;
+    uint64_t start_gpa, size;
     int ret;
 
     // Extract bits 5..3 from Exit Qualification
@@ -174,7 +174,7 @@ typedef struct epte_fixer_bundle {
     int error_count;
 } epte_fixer_bundle;
 
-static void fix_epte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
+static void fix_epte(hax_ept_tree *tree, uint64_t gfn, int level, hax_epte *epte,
                      void *opaque)
 {
     hax_epte old_epte, new_epte;
@@ -202,8 +202,8 @@ static void fix_epte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
         // should be zeroed out (i.e. not present)
         new_epte.value = 0;
     } else {
-        uint64 w_bit = HAX_EPT_PERM_RWX ^ HAX_EPT_PERM_RX;
-        uint64 preserved_bits;
+        uint64_t w_bit = HAX_EPT_PERM_RWX ^ HAX_EPT_PERM_RX;
+        uint64_t preserved_bits;
 
         // Set bits 2..0 (permissions)
         new_epte.value |= HAX_EPT_PERM_RWX;
@@ -258,9 +258,9 @@ static void fix_epte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
 // fix any misconfigured EPT entries in the EPT misconfiguration handler, and
 // log more information for further debugging.
 int ept_handle_misconfiguration(hax_gpa_space *gpa_space, hax_ept_tree *tree,
-                                uint64 gpa)
+                                uint64_t gpa)
 {
-    uint64 gfn;
+    uint64_t gfn;
     epte_fixer_bundle bundle = { NULL, 0, 0 };
 
     gfn = gpa >> PG_ORDER_4K;

--- a/core/ept_tree.c
+++ b/core/ept_tree.c
@@ -39,33 +39,33 @@ static hax_epte INVALID_EPTE = {
     // Other fields are initialized to 0
 };
 
-static inline uint get_pml4_index(uint64 gfn)
+static inline uint get_pml4_index(uint64_t gfn)
 {
     return (uint) (gfn >> (HAX_EPT_TABLE_SHIFT * 3));
 }
 
-static inline uint get_pdpt_gross_index(uint64 gfn)
+static inline uint get_pdpt_gross_index(uint64_t gfn)
 {
     return (uint) (gfn >> (HAX_EPT_TABLE_SHIFT * 2));
 }
 
-static inline uint get_pdpt_index(uint64 gfn)
+static inline uint get_pdpt_index(uint64_t gfn)
 {
     return (uint) ((gfn >> (HAX_EPT_TABLE_SHIFT * 2)) &
                    (HAX_EPT_TABLE_SIZE - 1));
 }
 
-static inline uint get_pd_gross_index(uint64 gfn)
+static inline uint get_pd_gross_index(uint64_t gfn)
 {
     return (uint) (gfn >> HAX_EPT_TABLE_SHIFT);
 }
 
-static inline uint get_pd_index(uint64 gfn)
+static inline uint get_pd_index(uint64_t gfn)
 {
     return (uint) ((gfn >> HAX_EPT_TABLE_SHIFT) & (HAX_EPT_TABLE_SIZE - 1));
 }
 
-static inline uint get_pt_index(uint64 gfn)
+static inline uint get_pt_index(uint64_t gfn)
 {
     return (uint) (gfn & (HAX_EPT_TABLE_SIZE - 1));
 }
@@ -100,7 +100,7 @@ static hax_ept_page * ept_tree_alloc_page(hax_ept_tree *tree)
 // The returned buffer can be used to fill the cache if it is not yet available.
 // Returns NULL if the |hax_ept_page| in question is not a frequently-used page.
 static inline hax_ept_page_kmap * ept_tree_get_freq_page(hax_ept_tree *tree,
-                                                         uint64 gfn, int level)
+                                                         uint64_t gfn, int level)
 {
     // Only HAX_EPT_FREQ_PAGE_COUNT EPT pages are considered frequently-used,
     // whose KVA mappings are cached in tree->freq_pages[]. They are:
@@ -147,7 +147,7 @@ int ept_tree_init(hax_ept_tree *tree)
     hax_ept_page *root_page;
     hax_ept_page_kmap *root_page_kmap;
     void *kva;
-    uint64 pfn;
+    uint64_t pfn;
 
     if (!tree) {
         hax_error("%s: tree == NULL\n", __func__);
@@ -267,7 +267,7 @@ static inline hax_epte * ept_tree_get_root_table(hax_ept_tree *tree)
 //                       that belongs to |current_table| and covers |gfn|. May
 //                       be NULL.
 // |opaque|: An arbitrary pointer passed as-is to |visit_current_epte|.
-static hax_epte * ept_tree_get_next_table(hax_ept_tree *tree, uint64 gfn,
+static hax_epte * ept_tree_get_next_table(hax_ept_tree *tree, uint64_t gfn,
                                           int current_level,
                                           hax_epte *current_table,
                                           hax_kmap_phys *kmap, bool create,
@@ -300,7 +300,7 @@ static hax_epte * ept_tree_get_next_table(hax_ept_tree *tree, uint64 gfn,
         // means the EPT entry pointing to the next-level page table is not
         // present, i.e. the next-level table does not exist
         hax_ept_page *page;
-        uint64 pfn;
+        uint64_t pfn;
         hax_epte temp_epte = { 0 };
         void *kva;
 
@@ -396,7 +396,7 @@ static inline void kmap_swap(hax_kmap_phys *kmap1, hax_kmap_phys *kmap2)
     *kmap2 = tmp;
 }
 
-int ept_tree_create_entry(hax_ept_tree *tree, uint64 gfn, hax_epte value)
+int ept_tree_create_entry(hax_ept_tree *tree, uint64_t gfn, hax_epte value)
 {
     hax_epte *table;
     int level;
@@ -457,18 +457,18 @@ int ept_tree_create_entry(hax_ept_tree *tree, uint64 gfn, hax_epte value)
     return 0;
 }
 
-int ept_tree_create_entries(hax_ept_tree *tree, uint64 start_gfn, uint64 npages,
-                            hax_chunk *chunk, uint64 offset_within_chunk,
-                            uint8 flags)
+int ept_tree_create_entries(hax_ept_tree *tree, uint64_t start_gfn, uint64_t npages,
+                            hax_chunk *chunk, uint64_t offset_within_chunk,
+                            uint8_t flags)
 {
     bool is_rom = flags & HAX_MEMSLOT_READONLY;
     hax_epte new_pte = { 0 };
-    uint64 gfn, end_gfn;
+    uint64_t gfn, end_gfn;
     hax_epte *pml4, *pdpt, *pd, *pt;
     hax_kmap_phys pdpt_kmap = { 0 }, pd_kmap = { 0 }, pt_kmap = { 0 };
     int ret;
     uint index, start_index, end_index;
-    uint64 offset = offset_within_chunk;
+    uint64_t offset = offset_within_chunk;
     int created_count = 0;
 
     assert(tree != NULL);
@@ -596,7 +596,7 @@ out:
     return ret;
 }
 
-void get_pte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
+void get_pte(hax_ept_tree *tree, uint64_t gfn, int level, hax_epte *epte,
              void *opaque)
 {
     hax_epte *pte;
@@ -612,7 +612,7 @@ void get_pte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
     *pte = *epte;
 }
 
-hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64 gfn)
+hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64_t gfn)
 {
     hax_epte pte = { 0 };
 
@@ -620,7 +620,7 @@ hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64 gfn)
     return pte;
 }
 
-void ept_tree_walk(hax_ept_tree *tree, uint64 gfn, epte_visitor visit_epte,
+void ept_tree_walk(hax_ept_tree *tree, uint64_t gfn, epte_visitor visit_epte,
                    void *opaque)
 {
     hax_epte *table;
@@ -662,7 +662,7 @@ void ept_tree_walk(hax_ept_tree *tree, uint64 gfn, epte_visitor visit_epte,
     assert(ret == 0);
 }
 
-void invalidate_pte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
+void invalidate_pte(hax_ept_tree *tree, uint64_t gfn, int level, hax_epte *epte,
                     void *opaque)
 {
     hax_epte *pte;
@@ -693,7 +693,7 @@ void invalidate_pte(hax_ept_tree *tree, uint64 gfn, int level, hax_epte *epte,
 
 // Returns 1 if the EPT leaf entry to be invalidated was present, or 0 if it is
 // not present.
-static int ept_tree_invalidate_entry(hax_ept_tree *tree, uint64 gfn)
+static int ept_tree_invalidate_entry(hax_ept_tree *tree, uint64_t gfn)
 {
     bool modified = false;
 
@@ -701,10 +701,10 @@ static int ept_tree_invalidate_entry(hax_ept_tree *tree, uint64 gfn)
     return modified ? 1 : 0;
 }
 
-int ept_tree_invalidate_entries(hax_ept_tree *tree, uint64 start_gfn,
-                                uint64 npages)
+int ept_tree_invalidate_entries(hax_ept_tree *tree, uint64_t start_gfn,
+                                uint64_t npages)
 {
-    uint64 end_gfn = start_gfn + npages, gfn;
+    uint64_t end_gfn = start_gfn + npages, gfn;
     int modified_count = 0;
 
     if (!tree) {
@@ -719,7 +719,7 @@ int ept_tree_invalidate_entries(hax_ept_tree *tree, uint64 start_gfn,
         modified_count += ret;
     }
     if (modified_count) {
-        if (hax_test_and_set_bit(0, (uint64 *) &tree->invept_pending)) {
+        if (hax_test_and_set_bit(0, (uint64_t *) &tree->invept_pending)) {
             hax_warning("%s: INVEPT pending flag is already set\n", __func__);
         }
     }

--- a/core/gpa_space.c
+++ b/core/gpa_space.c
@@ -60,7 +60,7 @@ int gpa_space_init(hax_gpa_space *gpa_space)
 }
 
 // Returns the protection bitmap size in bytes, or 0 on error.
-static uint gpa_space_prot_bitmap_size(uint64 npages)
+static uint gpa_space_prot_bitmap_size(uint64_t npages)
 {
     uint bitmap_size;
 
@@ -126,15 +126,15 @@ void gpa_space_remove_listener(hax_gpa_space *gpa_space,
 // (or write to it if |*writable| is true), with a size equal to the return
 // value. When it is done with the buffer, it must destroy |kmap| by calling
 // hax_unmap_user_pages().
-static int gpa_space_map_range(hax_gpa_space *gpa_space, uint64 start_gpa,
-                               int len, uint8 **buf, hax_kmap_user *kmap,
+static int gpa_space_map_range(hax_gpa_space *gpa_space, uint64_t start_gpa,
+                               int len, uint8_t **buf, hax_kmap_user *kmap,
                                bool *writable)
 {
-    uint64 gfn;
+    uint64_t gfn;
     uint delta, size, npages;
     hax_memslot *slot;
     hax_ramblock *block;
-    uint64 offset_within_block, offset_within_chunk;
+    uint64_t offset_within_block, offset_within_chunk;
     hax_chunk *chunk;
     void *kva;
 
@@ -197,14 +197,14 @@ static int gpa_space_map_range(hax_gpa_space *gpa_space, uint64 start_gpa,
         return -ENOMEM;
     }
     // Assuming buf != NULL
-    *buf = (uint8 *) kva + delta;
+    *buf = (uint8_t *) kva + delta;
     return (int) (size - delta);
 }
 
-int gpa_space_read_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
-                        uint8 *data)
+int gpa_space_read_data(hax_gpa_space *gpa_space, uint64_t start_gpa, int len,
+                        uint8_t *data)
 {
-    uint8 *buf;
+    uint8_t *buf;
     hax_kmap_user kmap;
     int ret, nbytes;
 
@@ -239,10 +239,10 @@ int gpa_space_read_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
     return nbytes;
 }
 
-int gpa_space_write_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
-                         uint8 *data)
+int gpa_space_write_data(hax_gpa_space *gpa_space, uint64_t start_gpa, int len,
+                         uint8_t *data)
 {
-    uint8 *buf;
+    uint8_t *buf;
     hax_kmap_user kmap;
     bool writable;
     int ret, nbytes;
@@ -284,10 +284,10 @@ int gpa_space_write_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
     return nbytes;
 }
 
-void * gpa_space_map_page(hax_gpa_space *gpa_space, uint64 gfn,
+void * gpa_space_map_page(hax_gpa_space *gpa_space, uint64_t gfn,
                           hax_kmap_user *kmap, bool *writable)
 {
-    uint8 *buf;
+    uint8_t *buf;
     int ret;
     void *kva;
 
@@ -315,13 +315,13 @@ void gpa_space_unmap_page(hax_gpa_space *gpa_space, hax_kmap_user *kmap)
     }
 }
 
-uint64 gpa_space_get_pfn(hax_gpa_space *gpa_space, uint64 gfn, uint8 *flags)
+uint64_t gpa_space_get_pfn(hax_gpa_space *gpa_space, uint64_t gfn, uint8_t *flags)
 {
     hax_memslot *slot;
     hax_ramblock *block;
     hax_chunk *chunk;
-    uint64 pfn;
-    uint64 offset_within_slot, offset_within_block, offset_within_chunk;
+    uint64_t pfn;
+    uint64_t offset_within_slot, offset_within_block, offset_within_chunk;
 
     assert(gpa_space != NULL);
 
@@ -366,11 +366,11 @@ uint64 gpa_space_get_pfn(hax_gpa_space *gpa_space, uint64 gfn, uint8 *flags)
     return pfn;
 }
 
-int gpa_space_adjust_prot_bitmap(hax_gpa_space *gpa_space, uint64 end_gfn)
+int gpa_space_adjust_prot_bitmap(hax_gpa_space *gpa_space, uint64_t end_gfn)
 {
     hax_gpa_prot *pb = &gpa_space->prot;
     uint new_size;
-    uint8 *bmold = pb->bitmap, *bmnew = NULL;
+    uint8_t *bmold = pb->bitmap, *bmnew = NULL;
 
     /* Bitmap size only grows until it is destroyed */
     if (end_gfn <= pb->end_gfn)
@@ -400,7 +400,7 @@ int gpa_space_adjust_prot_bitmap(hax_gpa_space *gpa_space, uint64 end_gfn)
 }
 
 // Sets or clears consecutive bits in a byte.
-static inline void set_bits_in_byte(uint8 *byte, int start, int nbits, bool set)
+static inline void set_bits_in_byte(uint8_t *byte, int start, int nbits, bool set)
 {
     uint mask;
 
@@ -410,20 +410,20 @@ static inline void set_bits_in_byte(uint8 *byte, int start, int nbits, bool set)
 
     mask = ((1 << nbits) - 1) << start;
     if (set) {
-        *byte = (uint8)(*byte | mask);
+        *byte = (uint8_t)(*byte | mask);
     } else {
         mask = ~mask & 0xff;
-        *byte = (uint8)(*byte & mask);
+        *byte = (uint8_t)(*byte & mask);
     }
 }
 
 // Sets or clears consecutive bits in a bitmap.
-static void set_bit_block(uint8 *bitmap, uint64 start, uint64 nbits, bool set)
+static void set_bit_block(uint8_t *bitmap, uint64_t start, uint64_t nbits, bool set)
 {
     // TODO: Is it safe to use 64-bit array indices on 32-bit hosts?
-    uint64 first_byte_index = start / 8;
-    uint64 last_byte_index = (start + nbits - 1) / 8;
-    uint64 i;
+    uint64_t first_byte_index = start / 8;
+    uint64_t last_byte_index = (start + nbits - 1) / 8;
+    uint64_t i;
     int first_bit_index = (int)(start % 8);
     int last_bit_index = (int)((start + nbits - 1) % 8);
 
@@ -441,7 +441,7 @@ static void set_bit_block(uint8 *bitmap, uint64 start, uint64 nbits, bool set)
     set_bits_in_byte(&bitmap[last_byte_index], 0, last_bit_index + 1, set);
 }
 
-bool gpa_space_is_page_protected(struct hax_gpa_space *gpa_space, uint64 gfn)
+bool gpa_space_is_page_protected(struct hax_gpa_space *gpa_space, uint64_t gfn)
 {
     struct hax_gpa_prot *pbm = &gpa_space->prot;
 
@@ -453,18 +453,18 @@ bool gpa_space_is_page_protected(struct hax_gpa_space *gpa_space, uint64 gfn)
 
     // Since gfn < pbm->end_gfn < 2^31 (cf. gpa_space_prot_bitmap_size()), it's
     // safe to convert it to int.
-    return hax_test_bit((int)gfn, (uint64 *)pbm->bitmap);
+    return hax_test_bit((int)gfn, (uint64_t *)pbm->bitmap);
 }
 
-bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64 gfn,
-                                  uint64 *fault_gfn)
+bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64_t gfn,
+                                  uint64_t *fault_gfn)
 {
 #define HAX_CHUNK_NR_PAGES (HAX_CHUNK_SIZE / PAGE_SIZE_4K)
     // FIXME: Chunks are created in HVA space (by dividing a RAM block), not in
     // GPA space. So rounding a GPA down to the nearest HAX_CHUNK_SIZE boundary
     // is not guaranteed to yield a GPA that maps to the same chunk.
-    uint64 start_gfn = gfn / HAX_CHUNK_NR_PAGES * HAX_CHUNK_NR_PAGES;
-    uint64 temp_gfn = start_gfn;
+    uint64_t start_gfn = gfn / HAX_CHUNK_NR_PAGES * HAX_CHUNK_NR_PAGES;
+    uint64_t temp_gfn = start_gfn;
 
     for (; temp_gfn < start_gfn + HAX_CHUNK_NR_PAGES; temp_gfn++)
         if (gpa_space_is_page_protected(gpa_space, temp_gfn)) {
@@ -476,10 +476,10 @@ bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64 gfn,
 }
 
 int gpa_space_protect_range(struct hax_gpa_space *gpa_space,
-                            uint64 start_gpa, uint64 len, uint32 flags)
+                            uint64_t start_gpa, uint64_t len, uint32_t flags)
 {
     uint perm = (uint)(flags & HAX_RAM_PERM_MASK);
-    uint64 first_gfn, last_gfn, npages;
+    uint64_t first_gfn, last_gfn, npages;
     hax_gpa_space_listener *listener;
 
     if (perm == HAX_RAM_PERM_NONE) {

--- a/core/hax.c
+++ b/core/hax.c
@@ -376,11 +376,11 @@ int hax_get_capability(void *buf, int bufLeng, int *outLength)
  * |read| and |write| determine if each MSR can be read or written freely by the
  * guest, respectively.
  */
-static void set_msr_access(uint32 start, uint32 count, bool read, bool write)
+static void set_msr_access(uint32_t start, uint32_t count, bool read, bool write)
 {
-    uint32 end = start + count - 1;
-    uint32 read_base, write_base, bit;
-    uint8 *msr_bitmap = hax_page_va(msr_bitmap_page);
+    uint32_t end = start + count - 1;
+    uint32_t read_base, write_base, bit;
+    uint8_t *msr_bitmap = hax_page_va(msr_bitmap_page);
 
     assert(((start ^ (start << 1)) & 0x80000000) == 0);
     assert((start & 0x3fffe000) == 0);
@@ -456,7 +456,7 @@ static void hax_pmu_init(void)
                 ref_pmu_info->apm_general_count > APM_MAX_GENERAL_COUNT
                 ? APM_MAX_GENERAL_COUNT : ref_pmu_info->apm_general_count;
         apm_general_bitlen = ref_pmu_info->apm_general_bitlen;
-        hax->apm_general_mask = apm_general_bitlen > 63 ? (uint64)-1
+        hax->apm_general_mask = apm_general_bitlen > 63 ? (uint64_t)-1
                                 : (1ULL << apm_general_bitlen) - 1;
         hax->apm_event_count =
                 ref_pmu_info->apm_event_count > APM_MAX_EVENT_COUNT
@@ -477,7 +477,7 @@ static void hax_pmu_init(void)
                     ref_pmu_info->apm_fixed_count > APM_MAX_FIXED_COUNT
                     ? APM_MAX_FIXED_COUNT : ref_pmu_info->apm_fixed_count;
             apm_fixed_bitlen = ref_pmu_info->apm_fixed_bitlen;
-            hax->apm_fixed_mask = apm_fixed_bitlen > 63 ? (uint64)-1
+            hax->apm_fixed_mask = apm_fixed_bitlen > 63 ? (uint64_t)-1
                                   : (1ULL << apm_fixed_bitlen) - 1;
             hax_info("APM: %u fixed-function counters, bitmask 0x%llx\n",
                      hax->apm_fixed_count, hax->apm_fixed_mask);

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -31,51 +31,51 @@
 #include "include/ia32.h"
 
 struct qword_val {
-    uint32 low;
-    uint32 high;
+    uint32_t low;
+    uint32_t high;
 };
 
 #ifdef _M_IX86
-extern void ASMCALL asm_rdmsr(uint32 reg, struct qword_val *qv);
-extern void ASMCALL asm_wrmsr(uint32 reg, struct qword_val *qv);
+extern void ASMCALL asm_rdmsr(uint32_t reg, struct qword_val *qv);
+extern void ASMCALL asm_wrmsr(uint32_t reg, struct qword_val *qv);
 extern void ASMCALL asm_rdtsc(struct qword_val *qv);
 #else  // !_M_IX86
-extern uint64 ASMCALL asm_rdmsr(uint32 reg);
-extern void ASMCALL asm_wrmsr(uint32 reg, uint64_t val);
-extern uint64 ASMCALL asm_rdtsc(void);
+extern uint64_t ASMCALL asm_rdmsr(uint32_t reg);
+extern void ASMCALL asm_wrmsr(uint32_t reg, uint64_t val);
+extern uint64_t ASMCALL asm_rdtsc(void);
 #endif  // _M_IX86
 
-uint64 ia32_rdmsr(uint32 reg)
+uint64_t ia32_rdmsr(uint32_t reg)
 {
 #ifdef _M_IX86
     struct qword_val val = { 0 };
 
     asm_rdmsr(reg, &val);
-    return ((uint64)(val.low) | (uint64)(val.high) << 32);
+    return ((uint64_t)(val.low) | (uint64_t)(val.high) << 32);
 #else
     return asm_rdmsr(reg);
 #endif
 }
 
-void ia32_wrmsr(uint32 reg, uint64 val)
+void ia32_wrmsr(uint32_t reg, uint64_t val)
 {
 #ifdef _M_IX86
     struct qword_val tmp = { 0 };
 
-    tmp.high = (uint32)(val >> 32);
-    tmp.low = (uint32)val;
+    tmp.high = (uint32_t)(val >> 32);
+    tmp.low = (uint32_t)val;
     asm_wrmsr(reg, &tmp);
 #else
     asm_wrmsr(reg, val);
 #endif
 }
 
-uint64 rdtsc(void)
+uint64_t rdtsc(void)
 {
 #ifdef _M_IX86
     struct qword_val val = { 0 };
     asm_rdtsc(&val);
-    return ((uint64)(val.low) | (uint64)(val.high) << 32);
+    return ((uint64_t)(val.low) | (uint64_t)(val.high) << 32);
 #else
     return asm_rdtsc();
 #endif
@@ -96,18 +96,18 @@ void fxrstor(mword *addr)
     asm_fxrstor(addr);
 }
 
-void btr(uint8 *addr, uint bit)
+void btr(uint8_t *addr, uint bit)
 {
     // asm_btr() may not be able to handle bit offsets greater than 0xff. For
     // absolute safety, ensure that the bit offset is less than 8.
-    uint8 *base = addr + bit / 8;
+    uint8_t *base = addr + bit / 8;
     uint offset = bit % 8;
     asm_btr(base, offset);
 }
 
-void bts(uint8 *addr, uint bit)
+void bts(uint8_t *addr, uint bit)
 {
-    uint8 *base = addr + bit / 8;
+    uint8_t *base = addr + bit / 8;
     uint offset = bit % 8;
     asm_bts(base, offset);
 }

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -42,7 +42,7 @@ extern void ASMCALL asm_rdtsc(struct qword_val *qv);
 #else  // !_M_IX86
 extern uint64 ASMCALL asm_rdmsr(uint32 reg);
 extern void ASMCALL asm_wrmsr(uint32 reg, uint64_t val);
-extern uint64 ASMCALL asm_rdtsc();
+extern uint64 ASMCALL asm_rdtsc(void);
 #endif  // _M_IX86
 
 uint64 ia32_rdmsr(uint32 reg)

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -35,19 +35,19 @@ struct qword_val {
     uint32_t high;
 };
 
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
 extern void ASMCALL asm_rdmsr(uint32_t reg, struct qword_val *qv);
 extern void ASMCALL asm_wrmsr(uint32_t reg, struct qword_val *qv);
 extern void ASMCALL asm_rdtsc(struct qword_val *qv);
-#else  // !_M_IX86
+#else  // !HAX_ARCH_X86_32
 extern uint64_t ASMCALL asm_rdmsr(uint32_t reg);
 extern void ASMCALL asm_wrmsr(uint32_t reg, uint64_t val);
 extern uint64_t ASMCALL asm_rdtsc(void);
-#endif  // _M_IX86
+#endif  // HAX_ARCH_X86_32
 
 uint64_t ia32_rdmsr(uint32_t reg)
 {
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     struct qword_val val = { 0 };
 
     asm_rdmsr(reg, &val);
@@ -59,7 +59,7 @@ uint64_t ia32_rdmsr(uint32_t reg)
 
 void ia32_wrmsr(uint32_t reg, uint64_t val)
 {
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     struct qword_val tmp = { 0 };
 
     tmp.high = (uint32_t)(val >> 32);
@@ -72,7 +72,7 @@ void ia32_wrmsr(uint32_t reg, uint64_t val)
 
 uint64_t rdtsc(void)
 {
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     struct qword_val val = { 0 };
     asm_rdtsc(&val);
     return ((uint64_t)(val.low) | (uint64_t)(val.high) << 32);

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -174,7 +174,7 @@ void cpu_exit_vmx(void *arg);
 
 void cpu_pmu_init(void *arg);
 
-void cpu_init_feature_cache();
+void cpu_init_feature_cache(void);
 bool cpu_has_feature(uint32_t feature);
 
 void hax_panic_log(struct vcpu_t *vcpu);

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -44,53 +44,53 @@
 struct vcpu_t;
 struct vcpu_state_t;
 
-typedef uint32 cpuid_t;  // CPU identifier
+typedef uint32_t cpuid_t;  // CPU identifier
 
 #define NR_HMSR 6
 
 struct hstate {
     /* ldt is not covered by host vmcs area */
-    uint16 ldt_selector;
-    uint16 ds;
-    uint16 es;
-    uint16 fs;
-    uint16 gs;
-    uint16 seg_valid;
+    uint16_t ldt_selector;
+    uint16_t ds;
+    uint16_t es;
+    uint16_t fs;
+    uint16_t gs;
+    uint16_t seg_valid;
 #define HOST_SEG_VALID_GS 0x1
 #define HOST_SEG_VALID_FS 0x2
 #define HOST_SEG_VALID_DS 0x4
 #define HOST_SEG_VALID_ES 0x8
-    uint16 seg_not_present;
+    uint16_t seg_not_present;
 #define HOST_SEG_NOT_PRESENT_GS 0x1
-    uint64 _efer;
-    uint64 gs_base;
-    uint64 fs_base;
-    uint64 hcr2;
+    uint64_t _efer;
+    uint64_t gs_base;
+    uint64_t fs_base;
+    uint64_t hcr2;
     struct vmx_msr hmsr[NR_HMSR];
     // IA32_PMCx, since APM v1
-    uint64 apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
+    uint64_t apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1
-    uint64 apm_pes_msrs[APM_MAX_GENERAL_COUNT];
+    uint64_t apm_pes_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_TSC_AUX
-    uint64 tsc_aux;
+    uint64_t tsc_aux;
     struct hax_page *hfxpage;
-    uint64 fake_gs;
+    uint64_t fake_gs;
     system_desc_t host_gdtr;
     system_desc_t host_idtr;
     // Debug registers
-    uint64 dr0;
-    uint64 dr1;
-    uint64 dr2;
-    uint64 dr3;
-    uint64 dr6;
+    uint64_t dr0;
+    uint64_t dr1;
+    uint64_t dr2;
+    uint64_t dr3;
+    uint64_t dr6;
 };
 
 struct hstate_compare {
-    uint32 cr0, cr2, cr3, cr4;
-    uint32 cs, ds, es, fs, gs, ss, ldt, tr;
-    uint32 cs_avail, ds_avail, es_avail, fs_avail, gs_avail, tr_avail, ss_avail;
-    uint64 sysenter_cs, sysenter_eip, sysenter_esp, efer, pat_msr, fs_msr;
-    uint64 gs_msr, rflags, rsp;
+    uint32_t cr0, cr2, cr3, cr4;
+    uint32_t cs, ds, es, fs, gs, ss, ldt, tr;
+    uint32_t cs_avail, ds_avail, es_avail, fs_avail, gs_avail, tr_avail, ss_avail;
+    uint64_t sysenter_cs, sysenter_eip, sysenter_esp, efer, pat_msr, fs_msr;
+    uint64_t gs_msr, rflags, rsp;
 };
 
 #define VMXON_HAX (1 << 0)
@@ -101,8 +101,8 @@ struct per_cpu_data {
     struct vcpu_t      *current_vcpu;
     paddr_t            other_vmcs;
     cpuid_t            cpu_id;
-    uint16             vmm_flag;
-    uint16             nested;
+    uint16_t           vmm_flag;
+    uint16_t           nested;
     mword              host_cr4_vmxe;
 
     /*
@@ -141,7 +141,7 @@ struct per_cpu_data {
 #define HAX_CPUF_ENABLE_EM64T   0x40
 
 #define HAX_CPUF_INITIALIZED    0x100
-    uint16                   cpu_features;
+    uint16_t                 cpu_features;
     info_t                   vmx_info;
     struct                   cpu_pmu_info pmu_info;
 #ifdef  DEBUG_HOST_STATE
@@ -154,11 +154,11 @@ struct per_cpu_data {
 extern struct per_cpu_data ** hax_cpu_data;
 static struct per_cpu_data * current_cpu_data(void)
 {
-    uint32 cpu_id = hax_cpuid();
+    uint32_t cpu_id = hax_cpuid();
     return hax_cpu_data[cpu_id];
 }
 
-static struct per_cpu_data * get_cpu_data(uint32 cpu_id)
+static struct per_cpu_data * get_cpu_data(uint32_t cpu_id)
 {
     return hax_cpu_data[cpu_id];
 }
@@ -184,9 +184,9 @@ vmx_result_t cpu_vmx_run(struct vcpu_t *vcpu, struct hax_tunnel *htun);
 int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun);
 
 void load_vmcs_common(struct vcpu_t *vcpu);
-uint32 load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
-uint32 put_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
-uint8 is_vmcs_loaded(struct vcpu_t *vcpu);
+uint32_t load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
+uint32_t put_vmcs(struct vcpu_t *vcpu, preempt_flag *flags);
+uint8_t is_vmcs_loaded(struct vcpu_t *vcpu);
 
 vmx_result_t cpu_vmxroot_leave(void);
 vmx_result_t cpu_vmxroot_enter(void);

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -229,11 +229,11 @@ typedef struct em_context_t {
 extern "C" {
 #endif
 
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
 #define EMCALL __stdcall
-#else  // !_M_IX86
+#else  // !HAX_ARCH_X86_32
 #define EMCALL
-#endif  // _M_IX86
+#endif  // HAX_ARCH_X86_32
 
 em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt,
                                   const uint8_t *insn);

--- a/core/include/ept.h
+++ b/core/include/ept.h
@@ -47,18 +47,18 @@
 
 typedef struct epte {
     union {
-        uint64 val;
+        uint64_t val;
         struct {
-            uint64 perm       : 3;
-            uint64 emt        : 3;
-            uint64 ignore_pat : 1;
-            uint64 large_page : 1;
-            uint64 accessed   : 1;
-            uint64 dirty      : 1;
-            uint64 dont_use   : 2;
-            uint64 addr       : 45;
-            uint64 rsvd       : 5;
-            uint64 avail1     : 2;
+            uint64_t perm       : 3;
+            uint64_t emt        : 3;
+            uint64_t ignore_pat : 1;
+            uint64_t large_page : 1;
+            uint64_t accessed   : 1;
+            uint64_t dirty      : 1;
+            uint64_t dont_use   : 2;
+            uint64_t addr       : 45;
+            uint64_t rsvd       : 5;
+            uint64_t avail1     : 2;
         };
     };
 } epte_t;
@@ -133,18 +133,18 @@ static inline uint ept_get_pte_idx(paddr_t gpa)
 
 typedef struct eptp {
     union {
-        uint64 val;
+        uint64_t val;
         struct {
-            uint64 emt    :  3;
-            uint64 gaw    :  3;
-            uint64 rsvd1  :  6;
-            uint64 asr    : 48;
-            uint64 rsvd2  :  4;
+            uint64_t emt    :  3;
+            uint64_t gaw    :  3;
+            uint64_t rsvd1  :  6;
+            uint64_t asr    : 48;
+            uint64_t rsvd2  :  4;
         };
     };
 } eptp_t;
 
-#define INVALID_EPTP ~(uint64)0
+#define INVALID_EPTP ~(uint64_t)0
 
 struct hax_ept {
     bool is_enabled;
@@ -161,36 +161,36 @@ static void construct_eptp(eptp_t *entry, paddr_t hpa, uint emt)
     entry->gaw = EPT_DEFAULT_GAW;
 };
 
-#define ept_cap_rwX             ((uint64)1 << 0)
-#define ept_cap_rWx             ((uint64)1 << 1)
-#define ept_cap_rWX             ((uint64)1 << 2)
-#define ept_cap_gaw21           ((uint64)1 << 3)
-#define ept_cap_gaw30           ((uint64)1 << 4)
-#define ept_cap_gaw39           ((uint64)1 << 5)
-#define ept_cap_gaw48           ((uint64)1 << 6)
-#define ept_cap_gaw57           ((uint64)1 << 7)
+#define ept_cap_rwX             ((uint64_t)1 << 0)
+#define ept_cap_rWx             ((uint64_t)1 << 1)
+#define ept_cap_rWX             ((uint64_t)1 << 2)
+#define ept_cap_gaw21           ((uint64_t)1 << 3)
+#define ept_cap_gaw30           ((uint64_t)1 << 4)
+#define ept_cap_gaw39           ((uint64_t)1 << 5)
+#define ept_cap_gaw48           ((uint64_t)1 << 6)
+#define ept_cap_gaw57           ((uint64_t)1 << 7)
 
-#define ept_cap_UC              ((uint64)1 << 8)
-#define ept_cap_WC              ((uint64)1 << 9)
-#define ept_cap_WT              ((uint64)1 << 12)
-#define ept_cap_WP              ((uint64)1 << 13)
-#define ept_cap_WB              ((uint64)1 << 14)
+#define ept_cap_UC              ((uint64_t)1 << 8)
+#define ept_cap_WC              ((uint64_t)1 << 9)
+#define ept_cap_WT              ((uint64_t)1 << 12)
+#define ept_cap_WP              ((uint64_t)1 << 13)
+#define ept_cap_WB              ((uint64_t)1 << 14)
 
-#define ept_cap_sp2M            ((uint64)1 << 16)
-#define ept_cap_sp1G            ((uint64)1 << 17)
-#define ept_cap_sp512G          ((uint64)1 << 18)
-#define ept_cap_sp256T          ((uint64)1 << 19)
+#define ept_cap_sp2M            ((uint64_t)1 << 16)
+#define ept_cap_sp1G            ((uint64_t)1 << 17)
+#define ept_cap_sp512G          ((uint64_t)1 << 18)
+#define ept_cap_sp256T          ((uint64_t)1 << 19)
 
-#define ept_cap_invept          ((uint64)1 << 20)
-#define ept_cap_invept_ia       ((uint64)1 << 24)
-#define ept_cap_invept_cw       ((uint64)1 << 25)
-#define ept_cap_invept_ac       ((uint64)1 << 26)
+#define ept_cap_invept          ((uint64_t)1 << 20)
+#define ept_cap_invept_ia       ((uint64_t)1 << 24)
+#define ept_cap_invept_cw       ((uint64_t)1 << 25)
+#define ept_cap_invept_ac       ((uint64_t)1 << 26)
 
-#define ept_cap_invvpid         ((uint64)1 << 32)
-#define ept_cap_invvpid_ia      ((uint64)1 << 40)
-#define ept_cap_invvpid_cw      ((uint64)1 << 41)
-#define ept_cap_invvpid_ac      ((uint64)1 << 42)
-#define ept_cap_invvpid_cwpg    ((uint64)1 << 43)
+#define ept_cap_invvpid         ((uint64_t)1 << 32)
+#define ept_cap_invvpid_ia      ((uint64_t)1 << 40)
+#define ept_cap_invvpid_cw      ((uint64_t)1 << 41)
+#define ept_cap_invvpid_ac      ((uint64_t)1 << 42)
+#define ept_cap_invvpid_cwpg    ((uint64_t)1 << 43)
 
 #define EPT_UNSUPPORTED_FEATURES \
         (ept_cap_sp2M | ept_cap_sp1G | ept_cap_sp512G | ept_cap_sp256T)
@@ -201,11 +201,11 @@ static void construct_eptp(eptp_t *entry, paddr_t hpa, uint emt)
 bool ept_init(hax_vm_t *hax_vm);
 void ept_free(hax_vm_t *hax_vm);
 
-uint64 vcpu_get_eptp(struct vcpu_t *vcpu);
+uint64_t vcpu_get_eptp(struct vcpu_t *vcpu);
 bool ept_set_pte(hax_vm_t *hax_vm, paddr_t gpa, paddr_t hpa, uint emt,
                  uint mem_type, bool *is_modified);
 void invept(hax_vm_t *hax_vm, uint type);
-bool ept_set_caps(uint64 caps);
+bool ept_set_caps(uint64_t caps);
 
 /* Deprecated API due to low performance */
 bool ept_translate(struct vcpu_t *vcpu, paddr_t gpa, uint order, paddr_t *hpa);

--- a/core/include/ept2.h
+++ b/core/include/ept2.h
@@ -53,30 +53,30 @@
 #define HAX_EPT_MEMTYPE_WB 0x6
 
 typedef union hax_epte {
-    uint64 value;
+    uint64_t value;
     struct {
-        uint64 perm          : 3;   // bits 2..0
-        uint64 ept_mt        : 3;   // bits 5..3
-        uint64 ignore_pat_mt : 1;   // bit 6
-        uint64 is_large_page : 1;   // bit 7
-        uint64 accessed      : 1;   // bit 8
-        uint64 dirty         : 1;   // bit 9
-        uint64 ignored1      : 2;   // bits 11..10
-        uint64 pfn           : 40;  // bits 51..12
-        uint64 ignored2      : 11;  // bits 62..52
-        uint64 supress_ve    : 1;   // bit 63
+        uint64_t perm          : 3;   // bits 2..0
+        uint64_t ept_mt        : 3;   // bits 5..3
+        uint64_t ignore_pat_mt : 1;   // bit 6
+        uint64_t is_large_page : 1;   // bit 7
+        uint64_t accessed      : 1;   // bit 8
+        uint64_t dirty         : 1;   // bit 9
+        uint64_t ignored1      : 2;   // bits 11..10
+        uint64_t pfn           : 40;  // bits 51..12
+        uint64_t ignored2      : 11;  // bits 62..52
+        uint64_t supress_ve    : 1;   // bit 63
     };
 } hax_epte;
 
 typedef union hax_eptp {
-    uint64 value;
+    uint64_t value;
     struct {
-        uint64 ept_mt       : 3;   // bits 2..0
-        uint64 max_level    : 3;   // bits 5..3
-        uint64 track_access : 1;   // bit 6
-        uint64 reserved1    : 5;   // bits 11..7
-        uint64 pfn          : 40;  // bits 51..12
-        uint64 reserved2    : 12;  // bits 63..52
+        uint64_t ept_mt       : 3;   // bits 2..0
+        uint64_t max_level    : 3;   // bits 5..3
+        uint64_t track_access : 1;   // bit 6
+        uint64_t reserved1    : 5;   // bits 11..7
+        uint64_t pfn          : 40;  // bits 51..12
+        uint64_t reserved2    : 12;  // bits 63..52
     };
 } hax_eptp;
 
@@ -139,7 +139,7 @@ void ept_tree_unlock(hax_ept_tree *tree);
 // -EEXIST: The leaf |hax_epte| corresponding to |gfn| is already present, whose
 //          value is different from |value|.
 // -ENOMEM: Memory allocation/mapping error.
-int ept_tree_create_entry(hax_ept_tree *tree, uint64 gfn, hax_epte value);
+int ept_tree_create_entry(hax_ept_tree *tree, uint64_t gfn, hax_epte value);
 
 // Creates leaf |hax_epte|s that map the given GFN range, using PFNs obtained
 // from the given |hax_chunk| and the given mapping properties. Also creates any
@@ -162,9 +162,9 @@ int ept_tree_create_entry(hax_ept_tree *tree, uint64 gfn, hax_epte value);
 // -EEXIST: Any of the leaf |hax_epte|s corresponding to the GFN range is
 //          already present and different from what would be created.
 // -ENOMEM: Memory allocation/mapping error.
-int ept_tree_create_entries(hax_ept_tree *tree, uint64 start_gfn, uint64 npages,
-                            hax_chunk *chunk, uint64 offset_within_chunk,
-                            uint8 flags);
+int ept_tree_create_entries(hax_ept_tree *tree, uint64_t start_gfn, uint64_t npages,
+                            hax_chunk *chunk, uint64_t offset_within_chunk,
+                            uint8_t flags);
 
 // Invalidates all leaf |hax_epte|s corresponding to the given GFN range, i.e.
 // marks them as not present. Also sets the |invept_pending| flag of the
@@ -178,13 +178,13 @@ int ept_tree_create_entries(hax_ept_tree *tree, uint64 start_gfn, uint64 npages,
 // to not present), or one of the following error codes:
 // -EINVAL: Invalid input, e.g. |tree| is NULL.
 // -ENOMEM: Memory mapping error.
-int ept_tree_invalidate_entries(hax_ept_tree *tree, uint64 start_gfn,
-                                uint64 npages);
+int ept_tree_invalidate_entries(hax_ept_tree *tree, uint64_t start_gfn,
+                                uint64_t npages);
 
 // Returns the leaf |hax_epte| that maps the given GFN. If the leaf |hax_epte|
 // does not exist, returns an all-zero |hax_epte|.
 // Returns an invalid |hax_epte| on error.
-hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64 gfn);
+hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64_t gfn);
 
 // A visitor callback invoked by ept_tree_walk() on each |hax_epte| visited
 // along the walk.
@@ -194,7 +194,7 @@ hax_epte ept_tree_get_entry(hax_ept_tree *tree, uint64 gfn);
 //          |HAX_EPT_LEVEL_*| constants.
 // |epte|: The |hax_epte| to visit.
 // |opaque|: Additional data provided by the caller of ept_tree_walk().
-typedef void (*epte_visitor)(hax_ept_tree *tree, uint64 gfn, int level,
+typedef void (*epte_visitor)(hax_ept_tree *tree, uint64_t gfn, int level,
                              hax_epte *epte, void *opaque);
 
 // Walks the given |hax_ept_tree| from the root as if the given GFN were being
@@ -206,7 +206,7 @@ typedef void (*epte_visitor)(hax_ept_tree *tree, uint64 gfn, int level,
 // |visit_epte|: The callback to be invoked on each |hax_epte| visited. Should
 //               not be NULL.
 // |opaque|: An arbitrary pointer passed as-is to |visit_current_epte|.
-void ept_tree_walk(hax_ept_tree *tree, uint64 gfn, epte_visitor visit_epte,
+void ept_tree_walk(hax_ept_tree *tree, uint64_t gfn, epte_visitor visit_epte,
                    void *opaque);
 
 // Handles a guest memory mapping change from RAM/ROM to MMIO. Used as a
@@ -218,8 +218,8 @@ void ept_tree_walk(hax_ept_tree *tree, uint64 gfn, epte_visitor visit_epte,
 // |flags|: The old mapping properties for the GFN range, e.g. whether it was
 //          mapped as read-only.
 void ept_handle_mapping_removed(hax_gpa_space_listener *listener,
-                                uint64 start_gfn, uint64 npages, uint64 uva,
-                                uint8 flags);
+                                uint64_t start_gfn, uint64_t npages, uint64_t uva,
+                                uint8_t flags);
 
 // Handles a guest memory mapping change from RAM/ROM to RAM/ROM. Used as a
 // |hax_gpa_space_listener| callback.
@@ -233,9 +233,9 @@ void ept_handle_mapping_removed(hax_gpa_space_listener *listener,
 // |new_flags|: The new mapping properties for the GFN range, e.g. whether it is
 //              mapped as read-only.
 void ept_handle_mapping_changed(hax_gpa_space_listener *listener,
-                                uint64 start_gfn, uint64 npages,
-                                uint64 old_uva, uint8 old_flags,
-                                uint64 new_uva, uint8 new_flags);
+                                uint64_t start_gfn, uint64_t npages,
+                                uint64_t old_uva, uint8_t old_flags,
+                                uint64_t new_uva, uint8_t new_flags);
 
 // Handles an EPT violation due to a guest RAM/ROM access.
 // |gpa_space|: The |hax_gpa_space| of the guest.
@@ -249,8 +249,8 @@ void ept_handle_mapping_changed(hax_gpa_space_listener *listener,
 //          present, but the access violates the permissions it allows.
 // -ENOMEM: Memory allocation/mapping error.
 int ept_handle_access_violation(hax_gpa_space *gpa_space, hax_ept_tree *tree,
-                                exit_qualification_t qual, uint64 gpa,
-                                uint64 *fault_gfn);
+                                exit_qualification_t qual, uint64_t gpa,
+                                uint64_t *fault_gfn);
 
 // Handles an EPT misconfiguration caught by hardware while it tries to
 // translate a GPA.
@@ -260,6 +260,6 @@ int ept_handle_access_violation(hax_gpa_space *gpa_space, hax_ept_tree *tree,
 // Returns the number of misconfigured |hax_epte|s that have been identified and
 // fixed, or a negative number if any misconfigured |hax_epte| cannot be fixed.
 int ept_handle_misconfiguration(hax_gpa_space *gpa_space, hax_ept_tree *tree,
-                                uint64 gpa);
+                                uint64_t gpa);
 
 #endif  // HAX_CORE_EPT2_H_

--- a/core/include/hax_core_interface.h
+++ b/core/include/hax_core_interface.h
@@ -39,8 +39,8 @@ struct vm_t;
 extern "C" {
 #endif
 
-int vcpu_set_msr(struct vcpu_t *vcpu, uint64 index, uint64 value);
-int vcpu_get_msr(struct vcpu_t *vcpu, uint64 index, uint64 *value);
+int vcpu_set_msr(struct vcpu_t *vcpu, uint64_t index, uint64_t value);
+int vcpu_get_msr(struct vcpu_t *vcpu, uint64_t index, uint64_t *value);
 int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_get_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *vs);
@@ -73,7 +73,7 @@ struct vcpu_t * vcpu_create(struct vm_t *vm, void *vm_host, int vcpu_id);
 int hax_vcpu_core_open(struct vcpu_t *vcpu);
 int vcpu_teardown(struct vcpu_t *vcpu);
 int vcpu_execute(struct vcpu_t *vcpu);
-int vcpu_interrupt(struct vcpu_t *vcpu, uint8 vector);
+int vcpu_interrupt(struct vcpu_t *vcpu, uint8_t vector);
 
 /*
  * Find a vcpu with corresponding id, |refer| decides whether a reference count

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -58,51 +58,51 @@ void ASMCALL set_dr3(mword val);
 void ASMCALL set_dr6(mword val);
 void ASMCALL set_dr7(mword val);
 
-uint16 ASMCALL get_kernel_cs(void);
-uint16 ASMCALL get_kernel_ds(void);
-uint16 ASMCALL get_kernel_es(void);
-uint16 ASMCALL get_kernel_ss(void);
-uint16 ASMCALL get_kernel_gs(void);
-uint16 ASMCALL get_kernel_fs(void);
+uint16_t ASMCALL get_kernel_cs(void);
+uint16_t ASMCALL get_kernel_ds(void);
+uint16_t ASMCALL get_kernel_es(void);
+uint16_t ASMCALL get_kernel_ss(void);
+uint16_t ASMCALL get_kernel_gs(void);
+uint16_t ASMCALL get_kernel_fs(void);
 
-void ASMCALL set_kernel_ds(uint16 val);
-void ASMCALL set_kernel_es(uint16 val);
-void ASMCALL set_kernel_gs(uint16 val);
-void ASMCALL set_kernel_fs(uint16 val);
+void ASMCALL set_kernel_ds(uint16_t val);
+void ASMCALL set_kernel_es(uint16_t val);
+void ASMCALL set_kernel_gs(uint16_t val);
+void ASMCALL set_kernel_fs(uint16_t val);
 
-void ASMCALL asm_btr(uint8 *addr, uint bit);
-void ASMCALL asm_bts(uint8 *addr, uint bit);
+void ASMCALL asm_btr(uint8_t *addr, uint bit);
+void ASMCALL asm_bts(uint8_t *addr, uint bit);
 void ASMCALL asm_fxinit(void);
 void ASMCALL asm_fxsave(mword *addr);
 void ASMCALL asm_fxrstor(mword *addr);
 void ASMCALL asm_cpuid(union cpuid_args_t *state);
 
 void ASMCALL __nmi(void);
-uint32 ASMCALL __fls(uint32 bit32);
+uint32_t ASMCALL __fls(uint32_t bit32);
 
-uint64 ia32_rdmsr(uint32 reg);
-void ia32_wrmsr(uint32 reg, uint64 val);
+uint64_t ia32_rdmsr(uint32_t reg);
+void ia32_wrmsr(uint32_t reg, uint64_t val);
 
-uint64 rdtsc(void);
+uint64_t rdtsc(void);
 
 void fxinit(void);
 void fxsave(mword *addr);
 void fxrstor(mword *addr);
 
-void btr(uint8 *addr, uint bit);
-void bts(uint8 *addr, uint bit);
+void btr(uint8_t *addr, uint bit);
+void bts(uint8_t *addr, uint bit);
 
 void ASMCALL asm_enable_irq(void);
 void ASMCALL asm_disable_irq(void);
 
-uint64 ASMCALL get_kernel_rflags(void);
-uint16 ASMCALL get_kernel_tr_selector(void);
+uint64_t ASMCALL get_kernel_rflags(void);
+uint16_t ASMCALL get_kernel_tr_selector(void);
 
 void ASMCALL set_kernel_gdt(struct system_desc_t *sys_desc);
 void ASMCALL set_kernel_idt(struct system_desc_t *sys_desc);
-void ASMCALL set_kernel_ldt(uint16 sel);
+void ASMCALL set_kernel_ldt(uint16_t sel);
 void ASMCALL get_kernel_gdt(struct system_desc_t *sys_desc);
 void ASMCALL get_kernel_idt(struct system_desc_t *sys_desc);
-uint16 ASMCALL get_kernel_ldt(void);
+uint16_t ASMCALL get_kernel_ldt(void);
 
 #endif  // HAX_CORE_IA32_H_

--- a/core/include/intr.h
+++ b/core/include/intr.h
@@ -42,17 +42,17 @@
 
 #define is_extern_interrupt(vec) (vec > 31)
 
-void hax_set_pending_intr(struct vcpu_t *vcpu, uint8 vector);
+void hax_set_pending_intr(struct vcpu_t *vcpu, uint8_t vector);
 uint hax_intr_is_blocked(struct vcpu_t *vcpu);
 void hax_handle_idt_vectoring(struct vcpu_t *vcpu);
 void vcpu_inject_intr(struct vcpu_t *vcpu, struct hax_tunnel *htun);
-void hax_inject_exception(struct vcpu_t *vcpu, uint8 vector, uint32 error_code);
+void hax_inject_exception(struct vcpu_t *vcpu, uint8_t vector, uint32_t error_code);
 /*
  * Get highest pending interrupt vector
  * Return HAX_INVALID_INTR_VECTOR when no pending
  */
 #define HAX_INVALID_INTR_VECTOR 0x100
-uint32 vcpu_get_pending_intrs(struct vcpu_t *vcpu);
+uint32_t vcpu_get_pending_intrs(struct vcpu_t *vcpu);
 static int hax_valid_vector(uint32_t vector)
 {
     return (vector <= 0xff);

--- a/core/include/memory.h
+++ b/core/include/memory.h
@@ -39,20 +39,20 @@
 
 typedef struct hax_chunk {
     hax_memdesc_user memdesc;
-    uint64 base_uva;
+    uint64_t base_uva;
     // In bytes, page-aligned, == HAX_CHUNK_SIZE in most cases
-    uint64 size;
+    uint64_t size;
 } hax_chunk;
 
 typedef struct hax_ramblock {
-    uint64 base_uva;
+    uint64_t base_uva;
     // In bytes, page-aligned
-    uint64 size;
+    uint64_t size;
     // hax_chunk *chunks[(size + HAX_CHUNK_SIZE - 1) / HAX_CHUNK_SIZE]
     hax_chunk **chunks;
     // One bit per chunk indicating whether the chunk has been (or is being)
     // allocated/pinned or not
-    uint8 *chunks_bitmap;
+    uint8_t *chunks_bitmap;
     // Reference count of this object
     int ref_count;
     // Turns this object into a list node
@@ -61,15 +61,15 @@ typedef struct hax_ramblock {
 
 typedef struct hax_memslot {
     // == base_gpa >> PG_ORDER_4K
-    uint64 base_gfn;
+    uint64_t base_gfn;
     // == size >> PG_ORDER_4K
-    uint64 npages;
+    uint64_t npages;
     // Must not be NULL
     struct hax_ramblock *block;
     // In bytes. < block->size
-    uint64 offset_within_block;
+    uint64_t offset_within_block;
     // Read-only, etc.
-    uint32 flags;
+    uint32_t flags;
     // Turns this object into a list node
     hax_list_node entry;
 } hax_memslot;
@@ -84,9 +84,9 @@ typedef struct hax_gpa_prot {
     // A bitmap where each bit represents the protection status of a guest page
     // frame: 1 means protected (i.e. no access allowed), 0 not protected.
     // TODO: Support fine-grained protection (R/W/X).
-    uint8 *bitmap;
+    uint8_t *bitmap;
     // the first gfn not covered by the bitmap
-    uint64 end_gfn;
+    uint64_t end_gfn;
 } hax_gpa_prot;
 
 typedef struct hax_gpa_space {
@@ -101,15 +101,15 @@ typedef struct hax_gpa_space {
 typedef struct hax_gpa_space_listener hax_gpa_space_listener;
 struct hax_gpa_space_listener {
     // For MMIO => RAM/ROM
-    void (*mapping_added)(hax_gpa_space_listener *listener, uint64 start_gfn,
-                          uint64 npages, uint64 uva, uint8 flags);
+    void (*mapping_added)(hax_gpa_space_listener *listener, uint64_t start_gfn,
+                          uint64_t npages, uint64_t uva, uint8_t flags);
     // For RAM/ROM => MMIO
-    void (*mapping_removed)(hax_gpa_space_listener *listener, uint64 start_gfn,
-                            uint64 npages, uint64 uva, uint8 flags);
+    void (*mapping_removed)(hax_gpa_space_listener *listener, uint64_t start_gfn,
+                            uint64_t npages, uint64_t uva, uint8_t flags);
     // For RAM/ROM => RAM/ROM
-    void (*mapping_changed)(hax_gpa_space_listener *listener, uint64 start_gfn,
-                            uint64 npages, uint64 old_uva, uint8 old_flags,
-                            uint64 new_uva, uint8 new_flags);
+    void (*mapping_changed)(hax_gpa_space_listener *listener, uint64_t start_gfn,
+                            uint64_t npages, uint64_t old_uva, uint8_t old_flags,
+                            uint64_t new_uva, uint8_t new_flags);
     hax_gpa_space *gpa_space;
     // Points to listener-specific data, e.g. a |hax_ept_tree|
     void *opaque;
@@ -137,7 +137,7 @@ void ramblock_dump_list(hax_list_head *list);
 //          head.
 // Returns a pointer to the |hax_ramblock| containing |uva|, or NULL if no such
 // |hax_ramblock| exists.
-hax_ramblock * ramblock_find(hax_list_head *list, uint64 uva,
+hax_ramblock * ramblock_find(hax_list_head *list, uint64_t uva,
                              hax_list_node *start);
 
 // Creates a |hax_ramblock| from the given UVA range and inserts it into the
@@ -154,7 +154,7 @@ hax_ramblock * ramblock_find(hax_list_head *list, uint64 uva,
 // -EINVAL: Invalid input, e.g. the given UVA range overlaps with that of an
 //          existing |hax_ramblock|.
 // -ENOMEM: Memory allocation error.
-int ramblock_add(hax_list_head *list, uint64 base_uva, uint64 size,
+int ramblock_add(hax_list_head *list, uint64_t base_uva, uint64_t size,
                  hax_list_node *start, hax_ramblock **block);
 
 // Returns the |hax_chunk| at the given offset in the given |hax_ramblock|’s UVA
@@ -173,7 +173,7 @@ int ramblock_add(hax_list_head *list, uint64 base_uva, uint64 size,
 // b) The |hax_chunk| has not been allocated and |alloc| is false.
 // c) The |hax_chunk| had not been allocated and |alloc| is true, but allocation
 //    was not successful.
-hax_chunk * ramblock_get_chunk(hax_ramblock *block, uint64 uva_offset,
+hax_chunk * ramblock_get_chunk(hax_ramblock *block, uint64_t uva_offset,
                                bool alloc);
 
 // Increments the reference count of an existing RAM block. The reference count
@@ -218,8 +218,8 @@ void memslot_dump_list(hax_gpa_space *gpa_space);
 // Returns 0 on success, or one of the following error codes:
 // -EINVAL: Invalid input.
 // -ENOMEM: Memory allocation error.
-int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
-                        uint64 npages, uint64 uva, uint32 flags);
+int memslot_set_mapping(hax_gpa_space *gpa_space, uint64_t start_gfn,
+                        uint64_t npages, uint64_t uva, uint32_t flags);
 
 // Finds in the given |hax_gpa_space| the |hax_memslot| containing the given
 // GFN.
@@ -227,7 +227,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
 // |gfn|: The GFN to search for.
 // Returns a pointer to the |hax_memslot| containing |gfn|, or NULL if no such
 // |hax_memslot| exists (indicating that |gfn| is reserved for MMIO).
-hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64 gfn);
+hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64_t gfn);
 
 // Initializes the given |hax_gpa_space|.
 // Returns 0 on success, or one of the following error codes:
@@ -260,8 +260,8 @@ void gpa_space_remove_listener(hax_gpa_space *gpa_space,
 // -EINVAL: Invalid input, e.g. |data| is NULL, or the GPA range specified by
 //          |start_gpa| and |len| touches an MMIO region.
 // -ENOMEM: Unable to map the requested guest page frames into KVA space.
-int gpa_space_read_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
-                        uint8 *data);
+int gpa_space_read_data(hax_gpa_space *gpa_space, uint64_t start_gpa, int len,
+                        uint8_t *data);
 
 // Copies the given number of bytes from the given buffer to guest RAM.
 // |gpa_space|: The |hax_gpa_space| of the guest.
@@ -278,8 +278,8 @@ int gpa_space_read_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
 // -ENOMEM: Unable to map the requested guest page frames into KVA space.
 // -EACCES: The GPA range specified by |start_gpa| and |len| touches a ROM
 //          region.
-int gpa_space_write_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
-                         uint8 *data);
+int gpa_space_write_data(hax_gpa_space *gpa_space, uint64_t start_gpa, int len,
+                         uint8_t *data);
 
 // Maps the given guest page frame into KVA space, stores the KVA mapping in the
 // given buffer, and returns the KVA. The caller must destroy the KVA mapping
@@ -292,7 +292,7 @@ int gpa_space_write_data(hax_gpa_space *gpa_space, uint64 start_gpa, int len,
 //             page frame is writable (i.e. maps to RAM). Can be NULL if the
 //             caller only wants to read from the page.
 // Returns NULL on error.
-void * gpa_space_map_page(hax_gpa_space *gpa_space, uint64 gfn,
+void * gpa_space_map_page(hax_gpa_space *gpa_space, uint64_t gfn,
                           hax_kmap_user *kmap, bool *writable);
 
 // Destroys the KVA mapping previously created by gpa_space_map_page().
@@ -306,21 +306,21 @@ void gpa_space_unmap_page(hax_gpa_space *gpa_space, hax_kmap_user *kmap);
 //          interested in this information.
 // Returns INVALID_PFN on error, including the case where |gfn| is reserved for
 // MMIO.
-uint64 gpa_space_get_pfn(hax_gpa_space *gpa_space, uint64 gfn, uint8 *flags);
+uint64_t gpa_space_get_pfn(hax_gpa_space *gpa_space, uint64_t gfn, uint8_t *flags);
 
 int gpa_space_protect_range(struct hax_gpa_space *gpa_space,
-                            uint64 start_gpa, uint64 len, uint32 flags);
+                            uint64_t start_gpa, uint64_t len, uint32_t flags);
 
 // Adjust gpa protection bitmap size. Once a bigger gfn is met, allocate
 // a new bitmap and copy the old bitmap contents.
 // |gpa_space|: The GPA space of the guest.
 // |end_gfn|: The first GFN not covered by the new bitmap.
 int gpa_space_adjust_prot_bitmap(struct hax_gpa_space *gpa_space,
-                                 uint64 end_gfn);
+                                 uint64_t end_gfn);
 
-bool gpa_space_is_page_protected(struct hax_gpa_space *gpa_space, uint64 gfn);
-bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64 gfn,
-                                  uint64 *fault_gfn);
+bool gpa_space_is_page_protected(struct hax_gpa_space *gpa_space, uint64_t gfn);
+bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64_t gfn,
+                                  uint64_t *fault_gfn);
 
 // Allocates a |hax_chunk| for the given UVA range, and pins the corresponding
 // host page frames in RAM.
@@ -331,7 +331,7 @@ bool gpa_space_is_chunk_protected(struct hax_gpa_space *gpa_space, uint64 gfn,
 // -EINVAL: Invalid input, e.g. |chunk| is NULL, or the UVA range given by
 //          |base_uva| and |size| is not valid.
 // -ENOMEM: Memory allocation error.
-int chunk_alloc(uint64 base_uva, uint64 size, hax_chunk **chunk);
+int chunk_alloc(uint64_t base_uva, uint64_t size, hax_chunk **chunk);
 
 // Frees up resources taken up by the given |hax_chunk|, which includes
 // unpinning all host page frames backing it.

--- a/core/include/mtrr.h
+++ b/core/include/mtrr.h
@@ -79,50 +79,50 @@ enum mtrr_msrs_t {
 };
 typedef enum mtrr_msrs_t mtrr_msrs_t;
 
-typedef uint64 mtrr_type_t;
+typedef uint64_t mtrr_type_t;
 
 union mtrr_cap_t {
-    uint64 raw;
+    uint64_t raw;
     struct {
-        uint64 num_var_range_regs : 8;
-        uint64 fix_support        : 1;
-        uint64 reserved1          : 1;
-        uint64 wc_type_support    : 1;
-        uint64 reserved2          : 53;
+        uint64_t num_var_range_regs : 8;
+        uint64_t fix_support        : 1;
+        uint64_t reserved1          : 1;
+        uint64_t wc_type_support    : 1;
+        uint64_t reserved2          : 53;
     };
 };
 typedef union mtrr_cap_t mtrr_cap_t;
 
 union mtrr_def_type_t {
-    uint64 raw;
+    uint64_t raw;
     struct {
-        uint64 type               : 8;
-        uint64 reserved1          : 2;
-        uint64 fixed_mtrr_enable  : 1;
-        uint64 var_mtrr_enable    : 1;
-        uint64 reserved2          : 52;
+        uint64_t type               : 8;
+        uint64_t reserved1          : 2;
+        uint64_t fixed_mtrr_enable  : 1;
+        uint64_t var_mtrr_enable    : 1;
+        uint64_t reserved2          : 52;
     };
 };
 typedef union mtrr_def_type_t mtrr_def_type_t;
 
 union mtrr_physbase_t {
-    uint64 raw;
+    uint64_t raw;
     struct {
-        uint64 type               : 8;
-        uint64 reserved1          : 4;
-        uint64 base               : 24;
-        uint64 reserved2          : 28;
+        uint64_t type               : 8;
+        uint64_t reserved1          : 4;
+        uint64_t base               : 24;
+        uint64_t reserved2          : 28;
     };
 };
 typedef union mtrr_physbase_t mtrr_physbase_t;
 
 union mtrr_physmask_t {
-    uint64 raw;
+    uint64_t raw;
     struct {
-        uint64 reserved1          : 11;
-        uint64 valid              : 1;
-        uint64 mask               : 24;
-        uint64 reserved2          : 28;
+        uint64_t reserved1          : 11;
+        uint64_t valid              : 1;
+        uint64_t mask               : 24;
+        uint64_t reserved2          : 28;
     };
 };
 typedef union mtrr_physmask_t mtrr_physmask_t;

--- a/core/include/page_walker.h
+++ b/core/include/page_walker.h
@@ -31,7 +31,7 @@
 #ifndef HAX_CORE_PAGE_WALKER_H_
 #define HAX_CORE_PAGE_WALKER_H_
 
-typedef uint64 ADDRESS;
+typedef uint64_t ADDRESS;
 
 #define ALIGN_BACKWARD(__address, __bytes)  \
         ((ADDRESS)(__address) & ~((__bytes) - 1))
@@ -44,7 +44,7 @@ typedef uint64 ADDRESS;
 #define PAGE_4MB_MASK       (PAGE_SIZE_4M - 1)
 #define PAGE_1GB_MASK       (PAGE_SIZE_1G - 1)
 
-#define PW_INVALID_GPA (~((uint64)0))
+#define PW_INVALID_GPA (~((uint64_t)0))
 #define PW_NUM_OF_PDPT_ENTRIES_IN_32_BIT_MODE 4
 
 /*
@@ -62,9 +62,9 @@ typedef uint64 ADDRESS;
  *       order   - PG_ORDER_4K, PG_ORDER_2M, PG_ORDER_4M, PG_ORDER_1G
  */
 
-uint32 pw_perform_page_walk(IN struct vcpu_t *vcpu, IN uint64 virt_addr,
-                            IN uint32 access, OUT uint64 *gpa_out,
-                            OUT uint *order, IN bool set_ad_bits,
-                            IN bool is_fetch);
+uint32_t pw_perform_page_walk(IN struct vcpu_t *vcpu, IN uint64_t virt_addr,
+                              IN uint32_t access, OUT uint64_t *gpa_out,
+                              OUT uint *order, IN bool set_ad_bits,
+                              IN bool is_fetch);
 
 #endif  // HAX_CORE_PAGE_WALKER_H_

--- a/core/include/pmu.h
+++ b/core/include/pmu.h
@@ -41,32 +41,32 @@
  */
 struct cpu_pmu_info {
     union {
-        uint32 cpuid_eax;
+        uint32_t cpuid_eax;
         struct {
             // Version ID of architectural performance monitoring (APM)
-            uint32 apm_version        : 8;
+            uint32_t apm_version        : 8;
             // Number of general-purpose performance monitoring counters
-            uint32 apm_general_count  : 8;
+            uint32_t apm_general_count  : 8;
             // Bit width of general-purpose performance monitoring counters
-            uint32 apm_general_bitlen : 8;
+            uint32_t apm_general_bitlen : 8;
             // Length of EBX bit vector
-            uint32 apm_event_count    : 8;
+            uint32_t apm_event_count    : 8;
         };
     };
     union {
-        uint32 cpuid_ebx;
+        uint32_t cpuid_ebx;
         // Bit vector to enumerate APM events
-        uint32 apm_event_unavailability;
+        uint32_t apm_event_unavailability;
     };
     union {
-        uint32 cpuid_edx;
+        uint32_t cpuid_edx;
         struct {
             // Number of fixed-function performance monitoring counters
-            uint32 apm_fixed_count  : 5;
+            uint32_t apm_fixed_count  : 5;
             // Bit width of fixed-function performance monitoring counters
-            uint32 apm_fixed_bitlen : 8;
+            uint32_t apm_fixed_bitlen : 8;
             // Reserved
-            uint32                  : 19;
+            uint32_t                  : 19;
         };
     };
 } PACKED;

--- a/core/include/segments.h
+++ b/core/include/segments.h
@@ -35,7 +35,7 @@
 // TODO: Get rid of is_compatible(), and then delete the following #include
 #include "../../include/hax_interface.h"
 
-#ifdef __WINNT__
+#ifdef HAX_COMPILER_MSVC
 #pragma pack(push, 1)
 #endif
 
@@ -64,7 +64,7 @@ struct PACKED system_desc_t {
     HAX_VADDR_T _base;
 };
 
-#ifdef __WINNT__
+#ifdef HAX_COMPILER_MSVC
 #pragma pack(pop)
 #endif
 
@@ -116,7 +116,7 @@ static inline uint64_t get_kernel_ldtr_base(void)
     ldt_sector = get_kernel_ldt();
     seg_desc = (struct seg_desc_t *)(gdtr_base) + (ldt_sector >> 3);
     desc_base = (seg_desc->_base0 + (seg_desc->_base1 << 24)) & 0xffffffff;
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     /* Table 3-2. TSS descriptor has 16 bytes on ia32e */
     desc_base = ((((struct seg_desc_t *)(seg_desc + 1))->_raw) << 32)
                 + (desc_base & 0xffffffff);
@@ -138,7 +138,7 @@ static inline uint64_t get_tr_desc_base(uint16_t selector)
     gdtr_base = get_kernel_gdtr_base();
     seg_desc = (struct seg_desc_t *)(gdtr_base) + (selector >> 3);
     desc_base = (seg_desc->_base0 + (seg_desc->_base1 << 24)) & 0xffffffff;
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     /* Table 3-2. TSS descriptor has 16 bytes on ia32e */
     desc_base = ((((struct seg_desc_t *)(seg_desc + 1))->_raw) << 32)
                 + (desc_base & 0xffffffff);

--- a/core/include/segments.h
+++ b/core/include/segments.h
@@ -42,25 +42,25 @@
 struct seg_desc_t {
     union {
         struct {
-            uint64 _limit0      : 16;
-            uint64 _base0       : 24;
-            uint64 _type        : 4;
-            uint64 _s           : 1;
-            uint64 _dpl         : 2;
-            uint64 _present     : 1;
-            uint64 _limit1      : 4;
-            uint64 _avl         : 1;
-            uint64 _longmode    : 1;
-            uint64 _d           : 1;
-            uint64 _granularity : 1;
-            uint64 _base1       : 8;
+            uint64_t _limit0      : 16;
+            uint64_t _base0       : 24;
+            uint64_t _type        : 4;
+            uint64_t _s           : 1;
+            uint64_t _dpl         : 2;
+            uint64_t _present     : 1;
+            uint64_t _limit1      : 4;
+            uint64_t _avl         : 1;
+            uint64_t _longmode    : 1;
+            uint64_t _d           : 1;
+            uint64_t _granularity : 1;
+            uint64_t _base1       : 8;
         } PACKED;
-        uint64 _raw;
+        uint64_t _raw;
     };
 };
 
 struct PACKED system_desc_t {
-    uint16 _limit;
+    uint16_t _limit;
     HAX_VADDR_T _base;
 };
 
@@ -71,12 +71,12 @@ struct PACKED system_desc_t {
 typedef struct system_desc_t system_desc_t;
 
 /*
- * This is to pass to VMCS, it should return uint64 on long or compatible mode
- * and return uint32 on pure 32-bit mode.
+ * This is to pass to VMCS, it should return uint64_t on long or compatible mode
+ * and return uint32_t on pure 32-bit mode.
  * TODO: Fix it in 32-bit environment
  */
 
-static inline uint64 get_kernel_gdtr_base_4vmcs(void)
+static inline uint64_t get_kernel_gdtr_base_4vmcs(void)
 {
     system_desc_t sys_desc;
 
@@ -85,7 +85,7 @@ static inline uint64 get_kernel_gdtr_base_4vmcs(void)
 }
 
 /*
- * In compatible mode, we need to return uint32.
+ * In compatible mode, we need to return uint32_t.
  * Good luck for us is Mac has dual map for this.
  */
 
@@ -97,7 +97,7 @@ static inline mword get_kernel_gdtr_base(void)
     return sys_desc._base;
 }
 
-static inline uint64 get_kernel_idtr_base(void)
+static inline uint64_t get_kernel_idtr_base(void)
 {
     system_desc_t sys_desc;
 
@@ -105,11 +105,11 @@ static inline uint64 get_kernel_idtr_base(void)
     return sys_desc._base;
 }
 
-static inline uint64 get_kernel_ldtr_base(void)
+static inline uint64_t get_kernel_ldtr_base(void)
 {
-    uint16 ldt_sector = 0;
+    uint16_t ldt_sector = 0;
     mword gdtr_base = 0;
-    uint64 desc_base;
+    uint64_t desc_base;
     struct seg_desc_t *seg_desc;
 
     gdtr_base = get_kernel_gdtr_base();
@@ -129,10 +129,10 @@ static inline uint64 get_kernel_ldtr_base(void)
     return desc_base;
 }
 
-static inline uint64 get_tr_desc_base(uint16 selector)
+static inline uint64_t get_tr_desc_base(uint16_t selector)
 {
     mword gdtr_base;
-    uint64 desc_base;
+    uint64_t desc_base;
     struct seg_desc_t *seg_desc;
 
     gdtr_base = get_kernel_gdtr_base();
@@ -151,7 +151,7 @@ static inline uint64 get_tr_desc_base(uint16 selector)
     return desc_base;
 }
 
-static inline uint32 get_kernel_fs_gs_base(uint16 selector)
+static inline uint32_t get_kernel_fs_gs_base(uint16_t selector)
 {
     mword gdtr_base;
     mword desc_base;
@@ -163,9 +163,9 @@ static inline uint32 get_kernel_fs_gs_base(uint16 selector)
     return desc_base;
 }
 
-static inline uint64 get_kernel_tr_base(void)
+static inline uint64_t get_kernel_tr_base(void)
 {
-    uint16 selector = get_kernel_tr_selector();
+    uint16_t selector = get_kernel_tr_selector();
     return get_tr_desc_base(selector);
 }
 

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -45,20 +45,20 @@
 struct gstate {
     struct vmx_msr gmsr[NR_GMSR];
     // IA32_PMCx, since APM v1
-    uint64 apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
+    uint64_t apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1
-    uint64 apm_pes_msrs[APM_MAX_GENERAL_COUNT];
+    uint64_t apm_pes_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_TSC_AUX
-    uint64 tsc_aux;
+    uint64_t tsc_aux;
     struct hax_page *gfxpage;
     // APIC_BASE MSR
-    uint64 apic_base;
+    uint64_t apic_base;
 };
 
 struct cvtlb {
     vaddr_t va;
     paddr_t ha;
-    uint64 flags;
+    uint64_t flags;
     uint guest_order;
     uint order;
     uint access;
@@ -69,31 +69,31 @@ struct hax_mmu;
 struct per_cpu_data;
 
 struct vcpu_vmx_data {
-    uint32 pin_ctls_base;
-    uint32 pcpu_ctls_base;
-    uint32 scpu_ctls_base;
-    uint32 entry_ctls_base;
-    uint32 exc_bitmap_base;
-    uint32 exit_ctls_base;
+    uint32_t pin_ctls_base;
+    uint32_t pcpu_ctls_base;
+    uint32_t scpu_ctls_base;
+    uint32_t entry_ctls_base;
+    uint32_t exc_bitmap_base;
+    uint32_t exit_ctls_base;
 
-    uint32 pin_ctls;
-    uint32 pcpu_ctls;
-    uint32 scpu_ctls;
-    uint32 entry_ctls;
-    uint32 exc_bitmap;
-    uint32 exit_ctls;
+    uint32_t pin_ctls;
+    uint32_t pcpu_ctls;
+    uint32_t scpu_ctls;
+    uint32_t entry_ctls;
+    uint32_t exc_bitmap;
+    uint32_t exit_ctls;
 
-    uint64 cr0_mask, cr0_shadow;
-    uint64 cr4_mask, cr4_shadow;
-    uint32 entry_exception_vector;
-    uint32 entry_exception_error_code;
+    uint64_t cr0_mask, cr0_shadow;
+    uint64_t cr4_mask, cr4_shadow;
+    uint32_t entry_exception_vector;
+    uint32_t entry_exception_error_code;
 
-    uint32 exit_exception_error_code;
+    uint32_t exit_exception_error_code;
     interruption_info_t exit_intr_info;
     interruption_info_t entry_intr_info;
-    uint32 exit_idt_vectoring;
-    uint32 exit_instr_length;
-    uint32 entry_instr_length;
+    uint32_t exit_idt_vectoring;
+    uint32_t exit_instr_length;
+    uint32_t entry_instr_length;
 
     exit_reason_t exit_reason;
     exit_qualification_t exit_qualification;
@@ -112,7 +112,7 @@ struct vcpu_post_mmio {
     } op;
     union {
         /* Index to the register to write to (for VCPU_POST_MMIO_WRITE_REG) */
-        uint8 reg_index;
+        uint8_t reg_index;
         /* GVA to write to (for VCPU_POST_MMIO_WRITE_MEM) */
         vaddr_t va;
     };
@@ -128,13 +128,13 @@ struct vcpu_post_mmio {
         VCPU_POST_MMIO_MANIP_XOR
     } manip;
     /* Another value (besides hax_fastmmio.value) for use by |manip| */
-    uint64 value;
+    uint64_t value;
 };
 
 #ifdef CONFIG_HAX_EPT2
 struct mmio_fetch_cache {
-    uint64 last_gva;
-    uint64 last_guest_cr3;
+    uint64_t last_gva;
+    uint64_t last_guest_cr3;
     void *kva;
     hax_kmap_user kmap;
     int hit_count;
@@ -144,8 +144,8 @@ struct mmio_fetch_cache {
 #define IOS_MAX_BUFFER 64
 
 struct vcpu_t {
-    uint16 vcpu_id;
-    uint16 cpu_id;
+    uint16_t vcpu_id;
+    uint16_t cpu_id;
     /*
      * VPID: Virtual Processor Identifier
      * VPIDs provide a way for software to identify to the processor
@@ -155,14 +155,14 @@ struct vcpu_t {
      * caches, even when non-zero PCIDs are not being used.
      * Reference: SDM, Volume 3, Chapter 4.11.2 & Chapter 28.1.
      */
-    uint16 vpid;
-    uint32 launched;
+    uint16_t vpid;
+    uint32_t launched;
     /*
      * This one should co-exist with the is_running and paused,
      * but considering this needs atomic, don't trouble to clean it now
      */
 #define VCPU_STATE_FLAGS_OPENED 0x1
-    uint64 flags;
+    uint64_t flags;
     hax_atomic_t ref_count;
     hax_list_head vcpu_list;
     hax_mutex tmutex;
@@ -171,29 +171,29 @@ struct vcpu_t {
     struct hax_mmu *mmu;
     struct vcpu_state_t *state;
     struct hax_tunnel *tunnel;
-    uint8 *io_buf;
+    uint8_t *io_buf;
     struct hax_page *vmcs_page;
     void *vcpu_host;
     struct {
-        uint64 paused                          : 1;
-        uint64 panicked                        : 1;
-        uint64 is_running                      : 1;
-        uint64 is_vmcs_loaded                  : 1;
-        uint64 event_injected                  : 1;
+        uint64_t paused                          : 1;
+        uint64_t panicked                        : 1;
+        uint64_t is_running                      : 1;
+        uint64_t is_vmcs_loaded                  : 1;
+        uint64_t event_injected                  : 1;
         /* vcpu->state is valid or not */
 #define GS_STALE      0
 #define GS_VALID      1
-        uint64 cur_state                       : 1;
-        uint64 vmcs_pending                    : 1;
-        uint64 vmcs_pending_entry_error_code   : 1;
-        uint64 vmcs_pending_entry_instr_length : 1;
-        uint64 vmcs_pending_entry_intr_info    : 1;
-        uint64 vmcs_pending_guest_cr3          : 1;
-        uint64 padding                         : 53;
+        uint64_t cur_state                       : 1;
+        uint64_t vmcs_pending                    : 1;
+        uint64_t vmcs_pending_entry_error_code   : 1;
+        uint64_t vmcs_pending_entry_instr_length : 1;
+        uint64_t vmcs_pending_entry_intr_info    : 1;
+        uint64_t vmcs_pending_guest_cr3          : 1;
+        uint64_t padding                         : 53;
     };
 
     /* For TSC offseting feature*/
-    int64 tsc_offset;
+    int64_t tsc_offset;
 
     /* vmx control and states */
     struct vcpu_vmx_data vmx;
@@ -204,17 +204,17 @@ struct vcpu_t {
 
     /* These GPAs will be loaded into VMCS fields PDPTE{0..3} when EPT is
      * enabled and the vCPU is about to enter PAE paging mode. */
-    uint64 pae_pdptes[4];
+    uint64_t pae_pdptes[4];
 
-    uint64 cr_pat;
-    uint64 cpuid_features_flag_mask;
+    uint64_t cr_pat;
+    uint64_t cpuid_features_flag_mask;
 
     /* Debugging */
-    uint32 debug_control;
+    uint32_t debug_control;
 
     /* Interrupt stuff */
-    uint32 intr_pending[8];
-    uint32 nr_pending_intrs;
+    uint32_t intr_pending[8];
+    uint32_t nr_pending_intrs;
 
     struct gstate gstate;
     struct hax_vcpu_mem *tunnel_vcpumem;
@@ -249,8 +249,8 @@ int vcpu_get_regs(struct vcpu_t *vcpu, struct vcpu_state_t *state);
 int vcpu_put_regs(struct vcpu_t *vcpu, struct vcpu_state_t *state);
 int vcpu_get_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
-int vcpu_get_msr(struct vcpu_t *vcpu, uint64 entry, uint64 *val);
-int vcpu_put_msr(struct vcpu_t *vcpu, uint64 entry, uint64 val);
+int vcpu_get_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t *val);
+int vcpu_put_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val);
 void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug);
 
 /* The declaration for OS wrapper code */
@@ -268,7 +268,7 @@ int vcpu_takeoff(struct vcpu_t *vcpu);
 void *vcpu_vmcs_va(struct vcpu_t *vcpu);
 paddr_t vcpu_vmcs_pa(struct vcpu_t *vcpu);
 int set_vcpu_tunnel(struct vcpu_t *vcpu, struct hax_tunnel *tunnel,
-                    uint8 *iobuf);
+                    uint8_t *iobuf);
 
 static inline bool valid_vcpu_id(int vcpu_id)
 {

--- a/core/include/vm.h
+++ b/core/include/vm.h
@@ -78,7 +78,7 @@ struct vm_t {
     hax_ept_tree ept_tree;
     hax_gpa_space_listener gpa_space_listener;
 #endif  // CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     uint64_t hva_limit;
     uint64_t hva_index;
     uint64_t hva_index_1;
@@ -126,7 +126,7 @@ enum run_flag {
 uint64_t hax_gpfn_to_hpa(struct vm_t *vm, uint64_t gpfn);
 
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
 void * hax_map_gpfn(struct vm_t *vm, uint64_t gpfn, bool flag, paddr_t cr3_cur,
                     uint8_t level);
 void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64_t gpfn);

--- a/core/include/vm.h
+++ b/core/include/vm.h
@@ -48,8 +48,8 @@
 #define HVA_MAP_ARRAY_SIZE             0x800000
 
 struct hax_p2m_entry {
-    uint64 hva;
-    uint64 hpa;
+    uint64_t hva;
+    uint64_t hpa;
 };
 
 #define VM_SPARE_RAMSIZE       0x5800000
@@ -65,11 +65,11 @@ struct vm_t {
     uint32_t features;
     int vm_id;
 #define VPID_SEED_BITS 64
-    uint8 vpid_seed[VPID_SEED_BITS / 8];
+    uint8_t vpid_seed[VPID_SEED_BITS / 8];
     int fd;
     hax_list_head hvm_list;
     hax_list_head vcpu_list;
-    uint16 bsp_vcpu_id;
+    uint16_t bsp_vcpu_id;
     void *vm_host;
     struct hax_ept *ept;
     void *p2m_map[MAX_GMEM_G];
@@ -91,11 +91,11 @@ struct vm_t {
 };
 
 struct hva_entry {
-    uint64 gpfn;
-    uint64 hva;
+    uint64_t gpfn;
+    uint64_t hva;
     paddr_t gcr3;
     bool is_kern;
-    uint8 level;
+    uint8_t level;
 };
 
 typedef struct vm_t hax_vm_t;
@@ -123,21 +123,21 @@ enum run_flag {
 #define gpfn_in_g(gpfn) ((gpfn) & 0x3ffff)
 #define GPFN_MAP_ARRAY_SIZE (1 << 22)
 
-uint64 hax_gpfn_to_hpa(struct vm_t *vm, uint64 gpfn);
+uint64_t hax_gpfn_to_hpa(struct vm_t *vm, uint64_t gpfn);
 
 #ifndef CONFIG_HAX_EPT2
 #if (!defined(__MACH__) && !defined(_WIN64))
-void * hax_map_gpfn(struct vm_t *vm, uint64 gpfn, bool flag, paddr_t cr3_cur,
-                    uint8 level);
-void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64 gpfn);
+void * hax_map_gpfn(struct vm_t *vm, uint64_t gpfn, bool flag, paddr_t cr3_cur,
+                    uint8_t level);
+void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64_t gpfn);
 #else
-void * hax_map_gpfn(struct vm_t *vm, uint64 gpfn);
+void * hax_map_gpfn(struct vm_t *vm, uint64_t gpfn);
 void hax_unmap_gpfn(void *va);
 #endif
 #endif // !CONFIG_HAX_EPT2
 
-int hax_core_set_p2m(struct vm_t *vm, uint64 gpfn, uint64 hpfn, uint64 hva,
-                     uint8 flags);
+int hax_core_set_p2m(struct vm_t *vm, uint64_t gpfn, uint64_t hpfn, uint64_t hva,
+                     uint8_t flags);
 struct vm_t *hax_create_vm(int *vm_id);
 int hax_teardown_vm(struct vm_t *vm);
 
@@ -146,6 +146,6 @@ void hax_teardown_vcpus(struct vm_t *vm);
 int hax_destroy_host_interface(void);
 int hax_vm_set_qemuversion(struct vm_t *vm, struct hax_qemu_version *ver);
 
-uint64 vm_get_eptp(struct vm_t *vm);
+uint64_t vm_get_eptp(struct vm_t *vm);
 
 #endif // HAX_CORE_VM_H_

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -502,7 +502,7 @@ enum {
     GAS_CSTATE      = 4
 };
 
-#ifdef __WINNT__
+#ifdef HAX_COMPILER_MSVC
 #pragma pack(push, 1)
 #endif
 
@@ -592,7 +592,7 @@ struct PACKED info_t {
     uint64_t             _ept_cap;
 };
 
-#ifdef __WINNT__
+#ifdef HAX_COMPILER_MSVC
 #pragma pack(pop)
 #endif
 
@@ -670,7 +670,7 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
         ((val).base  = vmread(vcpu, GUEST_##desc##_BASE),          \
          (val).limit = vmread(vcpu, GUEST_##desc##_LIMIT))
 
-#if defined(__WINNT__)
+#if defined(HAX_PLATFORM_WINDOWS)
 #define VMWRITE_SEG(vcpu, seg, val) {                              \
             uint32_t tmp_ar = val.ar;                              \
             if (tmp_ar == 0)                                       \
@@ -681,7 +681,7 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
             vmwrite(vcpu, GUEST_##seg##_AR, tmp_ar);               \
         }
 
-#elif defined(__MACH__)
+#elif defined(HAX_PLATFORM_DARWIN)
 #define VMWRITE_SEG(vcpu, seg, val) ({                             \
             uint32_t tmp_ar = val.ar;                              \
             if (tmp_ar == 0)                                       \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -213,65 +213,65 @@ typedef enum vmx_error_t {
 
 // Exit qualification 64-bit OK
 union exit_qualification_t {
-    uint64 raw;
-    uint64 address;
+    uint64_t raw;
+    uint64_t address;
     struct {
-        uint32 size        : 3;
-        uint32 direction   : 1;
-        uint32 string      : 1;
-        uint32 rep         : 1;
-        uint32 encoding    : 1;
-        uint32 rsv1        : 9;
-        uint32 port        : 16;
+        uint32_t size        : 3;
+        uint32_t direction   : 1;
+        uint32_t string      : 1;
+        uint32_t rep         : 1;
+        uint32_t encoding    : 1;
+        uint32_t rsv1        : 9;
+        uint32_t port        : 16;
     } io;
     struct {
-        uint32 creg        : 4;
-        uint32 type        : 2;
-        uint32 rsv2        : 2;
-        uint32 gpr         : 4;
-        uint32 rsv3        : 4;
-        uint32 lmsw_source : 16;
+        uint32_t creg        : 4;
+        uint32_t type        : 2;
+        uint32_t rsv2        : 2;
+        uint32_t gpr         : 4;
+        uint32_t rsv3        : 4;
+        uint32_t lmsw_source : 16;
     } cr;
     struct {
-        uint32 dreg        : 3;
-        uint32 rsv4        : 1;
-        uint32 direction   : 1;
-        uint32 rsv5        : 3;
-        uint32 gpr         : 4;
-        uint32 rsv6        : 20;
+        uint32_t dreg        : 3;
+        uint32_t rsv4        : 1;
+        uint32_t direction   : 1;
+        uint32_t rsv5        : 3;
+        uint32_t gpr         : 4;
+        uint32_t rsv6        : 20;
     } dr;
     struct {
-        uint32 selector    : 16;
-        uint32 rsv7        : 14;
-        uint32 source      : 2;
+        uint32_t selector    : 16;
+        uint32_t rsv7        : 14;
+        uint32_t source      : 2;
     } task_switch;
     struct {
-        uint32 offset      : 12;
-        uint32 access      : 3;
+        uint32_t offset      : 12;
+        uint32_t access      : 3;
     } vapic;
     struct {
-        uint8 vector;
+        uint8_t vector;
     } vapic_eoi;
     struct {
-        uint32 r           : 1;
-        uint32 w           : 1;
-        uint32 x           : 1;
-        uint32 _r          : 1;
-        uint32 _w          : 1;
-        uint32 _x          : 1;
-        uint32 res1        : 1;
-        uint32 gla1        : 1;
-        uint32 gla2        : 1;
+        uint32_t r           : 1;
+        uint32_t w           : 1;
+        uint32_t x           : 1;
+        uint32_t _r          : 1;
+        uint32_t _w          : 1;
+        uint32_t _x          : 1;
+        uint32_t res1        : 1;
+        uint32_t gla1        : 1;
+        uint32_t gla2        : 1;
         /*
          * According to latest IA SDM (September 2016), Table 27-7, these 3 bits
          * (11:9) are no longer reserved. They are meaningful if advanced
          * VM-exit information for EPT violations is supported by the processor,
          * which is the case with Kaby Lake.
          */
-        uint32 res2        : 3;  /* bits 11:9 */
-        uint32 nmi_block   : 1;
-        uint32 res3        : 19;
-        uint32 res4        : 32;
+        uint32_t res2        : 3;  /* bits 11:9 */
+        uint32_t nmi_block   : 1;
+        uint32_t res3        : 19;
+        uint32_t res4        : 32;
     } ept;
 };
 
@@ -279,14 +279,14 @@ typedef union exit_qualification_t exit_qualification_t;
 
 // Exit reason
 union exit_reason_t {
-    uint32 raw;
+    uint32_t raw;
     struct {
-        uint32 basic_reason : 16;
-        uint32 rsv          : 12;
-        uint32 pending_mtf  : 1;
-        uint32 vmexit_root  : 1;
-        uint32 vmexit_fail  : 1;
-        uint32 vmenter_fail : 1;
+        uint32_t basic_reason : 16;
+        uint32_t rsv          : 12;
+        uint32_t pending_mtf  : 1;
+        uint32_t vmexit_root  : 1;
+        uint32_t vmexit_fail  : 1;
+        uint32_t vmenter_fail : 1;
     };
 };
 
@@ -294,20 +294,20 @@ typedef union exit_reason_t exit_reason_t;
 
 // Instruction Information Layout (see spec: 8.6)
 union instruction_info_t {
-    uint32 raw;
+    uint32_t raw;
     struct {
-        uint32 scaling      : 2;
-        uint32              : 1;
-        uint32 register1    : 4;
-        uint32 addrsize     : 3;
-        uint32 memreg       : 1;
-        uint32              : 4;
-        uint32 segment      : 3;
-        uint32 indexreg     : 4;
-        uint32 indexinvalid : 1;
-        uint32 basereg      : 4;
-        uint32 baseinvalid  : 1;
-        uint32 register2    : 4;
+        uint32_t scaling      : 2;
+        uint32_t              : 1;
+        uint32_t register1    : 4;
+        uint32_t addrsize     : 3;
+        uint32_t memreg       : 1;
+        uint32_t              : 4;
+        uint32_t segment      : 3;
+        uint32_t indexreg     : 4;
+        uint32_t indexinvalid : 1;
+        uint32_t basereg      : 4;
+        uint32_t baseinvalid  : 1;
+        uint32_t register2    : 4;
     };
 };
 
@@ -315,14 +315,14 @@ typedef union instruction_info_t instruction_info_t;
 
 // 64-bit OK
 union interruption_info_t {
-    uint32 raw;
+    uint32_t raw;
     struct {
-        uint32 vector             : 8;
-        uint32 type               : 3;
-        uint32 deliver_error_code : 1;
-        uint32 nmi_unmasking      : 1;
-        uint32 reserved           : 18;
-        uint32 valid              : 1;
+        uint32_t vector             : 8;
+        uint32_t type               : 3;
+        uint32_t deliver_error_code : 1;
+        uint32_t nmi_unmasking      : 1;
+        uint32_t reserved           : 18;
+        uint32_t valid              : 1;
     };
 };
 
@@ -338,7 +338,7 @@ enum {
 
 typedef union interruption_info_t interruption_info_t;
 
-void get_interruption_info_t(interruption_info_t *info, uint8 v, uint8 t);
+void get_interruption_info_t(interruption_info_t *info, uint8_t v, uint8_t t);
 
 enum {
     GAS_ACTIVE      = 0,
@@ -355,87 +355,87 @@ enum {
 // 64-bit OK
 struct PACKED info_t {
     union {                          // 0: Basic Information
-        uint64         _basic_info;
+        uint64_t         _basic_info;
         struct {
-            uint32     _vmcs_revision_id;
+            uint32_t     _vmcs_revision_id;
             struct {
-                uint32 _vmcs_region_length : 16;
-                uint32 _phys_limit_32bit   : 1;
-                uint32 _par_mon_supported  : 1;
-                uint32 _mem_types          : 4;
-                uint32 _reserved1          : 10;
+                uint32_t _vmcs_region_length : 16;
+                uint32_t _phys_limit_32bit   : 1;
+                uint32_t _par_mon_supported  : 1;
+                uint32_t _mem_types          : 4;
+                uint32_t _reserved1          : 10;
             };
         };
     };
 
     union {
-        uint64         pin_ctls;
+        uint64_t         pin_ctls;
         struct {
-            uint32     pin_ctls_0;   // 1: Pin-Based VM-Execution Controls
-            uint32     pin_ctls_1;
+            uint32_t     pin_ctls_0;   // 1: Pin-Based VM-Execution Controls
+            uint32_t     pin_ctls_1;
         };
     };
 
     union {
-        uint64         pcpu_ctls;
+        uint64_t         pcpu_ctls;
         struct {
-            uint32     pcpu_ctls_0;  // 2: Processor-Based VM-Execution Controls
-            uint32     pcpu_ctls_1;
+            uint32_t     pcpu_ctls_0;  // 2: Processor-Based VM-Execution Controls
+            uint32_t     pcpu_ctls_1;
         };
     };
 
     union {
-        uint64         exit_ctls;
+        uint64_t         exit_ctls;
         struct {
-            uint32     exit_ctls_0;  // 3: Allowed VM-Exit Controls
-            uint32     exit_ctls_1;
+            uint32_t     exit_ctls_0;  // 3: Allowed VM-Exit Controls
+            uint32_t     exit_ctls_1;
         };
     };
 
     union {
-        uint64         entry_ctls;
+        uint64_t         entry_ctls;
         struct {
-            uint32     entry_ctls_0; // 4: Allowed VM-Entry Controls
-            uint32     entry_ctls_1;
+            uint32_t     entry_ctls_0; // 4: Allowed VM-Entry Controls
+            uint32_t     entry_ctls_1;
         };
     };
 
     union {                          // 5: Miscellaneous Data
-        uint64         _miscellaneous;
+        uint64_t         _miscellaneous;
         struct {
             struct {
-                uint32 _tsc_comparator_len : 6;
-                uint32 _reserved2          : 2;
-                uint32 _max_sleep_state    : 8;
-                uint32 _max_cr3_targets    : 9;
-                uint32 _reserved3          : 7;
+                uint32_t _tsc_comparator_len : 6;
+                uint32_t _reserved2          : 2;
+                uint32_t _max_sleep_state    : 8;
+                uint32_t _max_cr3_targets    : 9;
+                uint32_t _reserved3          : 7;
             };
-            uint32     _mseg_revision_id;
+            uint32_t     _mseg_revision_id;
         };
     };
 
-    uint64             _cr0_fixed_0; // 6: VMX-Fixed Bits in CR0
-    uint64             _cr0_fixed_1; // 7: VMX-Fixed Bits in CR0
-    uint64             _cr4_fixed_0; // 8: VMX-Fixed Bits in CR4
-    uint64             _cr4_fixed_1; // 9: VMX-Fixed Bits in CR4
+    uint64_t             _cr0_fixed_0; // 6: VMX-Fixed Bits in CR0
+    uint64_t             _cr0_fixed_1; // 7: VMX-Fixed Bits in CR0
+    uint64_t             _cr4_fixed_0; // 8: VMX-Fixed Bits in CR4
+    uint64_t             _cr4_fixed_1; // 9: VMX-Fixed Bits in CR4
 
     union {                          // 10: VMCS Enumeration
-        uint64         _vmcs_enumeration;
+        uint64_t         _vmcs_enumeration;
         struct {
-                uint32                     : 1;
-                uint32 _max_vmcs_idx       : 9;
+                uint32_t                     : 1;
+                uint32_t _max_vmcs_idx       : 9;
         };
     };
 
     union {
-        uint64         scpu_ctls;
+        uint64_t         scpu_ctls;
         struct {
-            uint32     scpu_ctls_0;  // 2: Processor-Based VM-Execution Controls
-            uint32     scpu_ctls_1;
+            uint32_t     scpu_ctls_0;  // 2: Processor-Based VM-Execution Controls
+            uint32_t     scpu_ctls_1;
         };
     };
 
-    uint64             _ept_cap;
+    uint64_t             _ept_cap;
 };
 
 #ifdef __WINNT__
@@ -445,19 +445,19 @@ struct PACKED info_t {
 typedef struct PACKED info_t info_t;
 // 64-bit OK
 struct mseg_header_t {
-    uint32 mseg_revision_id;
-    uint32 smm_monitor_features;
-    uint32 gdtr_limit;
-    uint32 gdtr_base;
-    uint32 cs;
-    uint32 eip;
-    uint32 esp;
-    uint32 cr3;
+    uint32_t mseg_revision_id;
+    uint32_t smm_monitor_features;
+    uint32_t gdtr_limit;
+    uint32_t gdtr_base;
+    uint32_t cs;
+    uint32_t eip;
+    uint32_t esp;
+    uint32_t cr3;
 };
 
 union vmcs_t {
-    uint32 _revision_id;
-    uint8 _raw8[IA32_VMX_VMCS_SIZE];
+    uint32_t _revision_id;
+    uint8_t _raw8[IA32_VMX_VMCS_SIZE];
 };
 
 typedef union vmcs_t vmcs_t;
@@ -475,8 +475,8 @@ typedef enum encode_t encode_t;
 #define ENCODE_SHIFT    13
 
 struct invept_desc {
-    uint64 eptp;
-    uint64 rsvd;
+    uint64_t eptp;
+    uint64_t rsvd;
 };
 
 struct vcpu_state_t;
@@ -488,17 +488,17 @@ vmx_result_t ASMCALL asm_vmptrld(const paddr_t *addr_in);
 vmx_result_t ASMCALL asm_vmxon(const paddr_t *addr_in);
 vmx_result_t ASMCALL asm_vmxoff(void);
 vmx_result_t ASMCALL asm_vmptrst(paddr_t *addr_out);
-vmx_result_t ASMCALL asm_vmxrun(struct vcpu_state_t *state, uint16 launch);
+vmx_result_t ASMCALL asm_vmxrun(struct vcpu_state_t *state, uint16_t launch);
 
 mword ASMCALL vmx_get_rip(void);
 
-mword ASMCALL asm_vmread(uint32 component);
-void ASMCALL asm_vmwrite(uint32 component, mword val);
+mword ASMCALL asm_vmread(uint32_t component);
+void ASMCALL asm_vmwrite(uint32_t component, mword val);
 
-uint64 vmread(struct vcpu_t *vcpu, component_index_t component);
-uint64 vmread_dump(struct vcpu_t *vcpu, unsigned enc, char *name);
+uint64_t vmread(struct vcpu_t *vcpu, component_index_t component);
+uint64_t vmread_dump(struct vcpu_t *vcpu, unsigned enc, char *name);
 void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
-                 component_index_t component, uint64 source_val);
+                 component_index_t component, uint64_t source_val);
 
 #define vmwrite(vcpu, x, y) vmx_vmwrite(vcpu, #x, x, y)
 

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -102,6 +102,160 @@ enum {
     VMX_EXIT_XRSTORS                 = 64
 };
 
+enum component_index_t {
+    VMX_PIN_CONTROLS                            = 0x00004000,
+    VMX_PRIMARY_PROCESSOR_CONTROLS              = 0x00004002,
+    VMX_SECONDARY_PROCESSOR_CONTROLS            = 0x0000401e,
+    VMX_EXCEPTION_BITMAP                        = 0x00004004,
+    VMX_PAGE_FAULT_ERROR_CODE_MASK              = 0x00004006,
+    VMX_PAGE_FAULT_ERROR_CODE_MATCH             = 0x00004008,
+    VMX_EXIT_CONTROLS                           = 0x0000400c,
+    VMX_EXIT_MSR_STORE_COUNT                    = 0x0000400e,
+    VMX_EXIT_MSR_LOAD_COUNT                     = 0x00004010,
+    VMX_ENTRY_CONTROLS                          = 0x00004012,
+    VMX_ENTRY_MSR_LOAD_COUNT                    = 0x00004014,
+    VMX_ENTRY_INTERRUPT_INFO                    = 0x00004016,
+    VMX_ENTRY_EXCEPTION_ERROR_CODE              = 0x00004018,
+    VMX_ENTRY_INSTRUCTION_LENGTH                = 0x0000401a,
+    VMX_TPR_THRESHOLD                           = 0x0000401c,
+
+    VMX_CR0_MASK                                = 0x00006000,
+    VMX_CR4_MASK                                = 0x00006002,
+    VMX_CR0_READ_SHADOW                         = 0x00006004,
+    VMX_CR4_READ_SHADOW                         = 0x00006006,
+    VMX_CR3_TARGET_COUNT                        = 0x0000400a,
+    VMX_CR3_TARGET_VAL_BASE                     = 0x00006008, // x6008-x6206
+
+    VMX_VPID                                    = 0x00000000,
+    VMX_IO_BITMAP_A                             = 0x00002000,
+    VMX_IO_BITMAP_B                             = 0x00002002,
+    VMX_MSR_BITMAP                              = 0x00002004,
+    VMX_EXIT_MSR_STORE_ADDRESS                  = 0x00002006,
+    VMX_EXIT_MSR_LOAD_ADDRESS                   = 0x00002008,
+    VMX_ENTRY_MSR_LOAD_ADDRESS                  = 0x0000200a,
+    VMX_TSC_OFFSET                              = 0x00002010,
+    VMX_VAPIC_PAGE                              = 0x00002012,
+    VMX_APIC_ACCESS_PAGE                        = 0x00002014,
+    VMX_EPTP                                    = 0x0000201a,
+    VMX_PREEMPTION_TIMER                        = 0x0000482e,
+
+    VMX_INSTRUCTION_ERROR_CODE                  = 0x00004400,
+
+    VM_EXIT_INFO_REASON                         = 0x00004402,
+    VM_EXIT_INFO_INTERRUPT_INFO                 = 0x00004404,
+    VM_EXIT_INFO_EXCEPTION_ERROR_CODE           = 0x00004406,
+    VM_EXIT_INFO_IDT_VECTORING                  = 0x00004408,
+    VM_EXIT_INFO_IDT_VECTORING_ERROR_CODE       = 0x0000440a,
+    VM_EXIT_INFO_INSTRUCTION_LENGTH             = 0x0000440c,
+    VM_EXIT_INFO_INSTRUCTION_INFO               = 0x0000440e,
+    VM_EXIT_INFO_QUALIFICATION                  = 0x00006400,
+    VM_EXIT_INFO_IO_ECX                         = 0x00006402,
+    VM_EXIT_INFO_IO_ESI                         = 0x00006404,
+    VM_EXIT_INFO_IO_EDI                         = 0x00006406,
+    VM_EXIT_INFO_IO_EIP                         = 0x00006408,
+    VM_EXIT_INFO_GUEST_LINEAR_ADDRESS           = 0x0000640a,
+    VM_EXIT_INFO_GUEST_PHYSICAL_ADDRESS         = 0x00002400,
+
+    HOST_RIP                                    = 0x00006c16,
+    HOST_RSP                                    = 0x00006c14,
+    HOST_CR0                                    = 0x00006c00,
+    HOST_CR3                                    = 0x00006c02,
+    HOST_CR4                                    = 0x00006c04,
+
+    HOST_CS_SELECTOR                            = 0x00000c02,
+    HOST_DS_SELECTOR                            = 0x00000c06,
+    HOST_ES_SELECTOR                            = 0x00000c00,
+    HOST_FS_SELECTOR                            = 0x00000c08,
+    HOST_GS_SELECTOR                            = 0x00000c0a,
+    HOST_SS_SELECTOR                            = 0x00000c04,
+    HOST_TR_SELECTOR                            = 0x00000c0c,
+    HOST_FS_BASE                                = 0x00006c06,
+    HOST_GS_BASE                                = 0x00006c08,
+    HOST_TR_BASE                                = 0x00006c0a,
+    HOST_GDTR_BASE                              = 0x00006c0c,
+    HOST_IDTR_BASE                              = 0x00006c0e,
+
+    HOST_SYSENTER_CS                            = 0x00004c00,
+    HOST_SYSENTER_ESP                           = 0x00006c10,
+    HOST_SYSENTER_EIP                           = 0x00006c12,
+
+    HOST_PAT                                    = 0x00002c00,
+    HOST_EFER                                   = 0x00002c02,
+    HOST_PERF_GLOBAL_CTRL                       = 0x00002c04,
+
+
+    GUEST_RIP                                   = 0x0000681e,
+    GUEST_RFLAGS                                = 0x00006820,
+    GUEST_RSP                                   = 0x0000681c,
+    GUEST_CR0                                   = 0x00006800,
+    GUEST_CR3                                   = 0x00006802,
+    GUEST_CR4                                   = 0x00006804,
+
+    GUEST_ES_SELECTOR                           = 0x00000800,
+    GUEST_CS_SELECTOR                           = 0x00000802,
+    GUEST_SS_SELECTOR                           = 0x00000804,
+    GUEST_DS_SELECTOR                           = 0x00000806,
+    GUEST_FS_SELECTOR                           = 0x00000808,
+    GUEST_GS_SELECTOR                           = 0x0000080a,
+    GUEST_LDTR_SELECTOR                         = 0x0000080c,
+    GUEST_TR_SELECTOR                           = 0x0000080e,
+
+    GUEST_ES_AR                                 = 0x00004814,
+    GUEST_CS_AR                                 = 0x00004816,
+    GUEST_SS_AR                                 = 0x00004818,
+    GUEST_DS_AR                                 = 0x0000481a,
+    GUEST_FS_AR                                 = 0x0000481c,
+    GUEST_GS_AR                                 = 0x0000481e,
+    GUEST_LDTR_AR                               = 0x00004820,
+    GUEST_TR_AR                                 = 0x00004822,
+
+    GUEST_ES_BASE                               = 0x00006806,
+    GUEST_CS_BASE                               = 0x00006808,
+    GUEST_SS_BASE                               = 0x0000680a,
+    GUEST_DS_BASE                               = 0x0000680c,
+    GUEST_FS_BASE                               = 0x0000680e,
+    GUEST_GS_BASE                               = 0x00006810,
+    GUEST_LDTR_BASE                             = 0x00006812,
+    GUEST_TR_BASE                               = 0x00006814,
+    GUEST_GDTR_BASE                             = 0x00006816,
+    GUEST_IDTR_BASE                             = 0x00006818,
+
+    GUEST_ES_LIMIT                              = 0x00004800,
+    GUEST_CS_LIMIT                              = 0x00004802,
+    GUEST_SS_LIMIT                              = 0x00004804,
+    GUEST_DS_LIMIT                              = 0x00004806,
+    GUEST_FS_LIMIT                              = 0x00004808,
+    GUEST_GS_LIMIT                              = 0x0000480a,
+    GUEST_LDTR_LIMIT                            = 0x0000480c,
+    GUEST_TR_LIMIT                              = 0x0000480e,
+    GUEST_GDTR_LIMIT                            = 0x00004810,
+    GUEST_IDTR_LIMIT                            = 0x00004812,
+
+    GUEST_VMCS_LINK_PTR                         = 0x00002800,
+    GUEST_DEBUGCTL                              = 0x00002802,
+    GUEST_PAT                                   = 0x00002804,
+    GUEST_EFER                                  = 0x00002806,
+    GUEST_PERF_GLOBAL_CTRL                      = 0x00002808,
+    GUEST_PDPTE0                                = 0x0000280a,
+    GUEST_PDPTE1                                = 0x0000280c,
+    GUEST_PDPTE2                                = 0x0000280e,
+    GUEST_PDPTE3                                = 0x00002810,
+
+    GUEST_DR7                                   = 0x0000681a,
+    GUEST_PENDING_DBE                           = 0x00006822,
+    GUEST_SYSENTER_CS                           = 0x0000482a,
+    GUEST_SYSENTER_ESP                          = 0x00006824,
+    GUEST_SYSENTER_EIP                          = 0x00006826,
+    GUEST_SMBASE                                = 0x00004828,
+    GUEST_INTERRUPTIBILITY                      = 0x00004824,
+    GUEST_ACTIVITY_STATE                        = 0x00004826,
+
+    /* Invalid encoding */
+    VMCS_NO_COMPONENT                           = 0x0000ffff
+};
+
+typedef enum component_index_t component_index_t;
+
 // PIN-BASED CONTROLS
 #define EXT_INTERRUPT_EXITING                  0x00000001
 #define NMI_EXITING                            0x00000008

--- a/core/include/vtlb.h
+++ b/core/include/vtlb.h
@@ -62,12 +62,12 @@ typedef enum mmu_mode {
     MMU_MODE_EPT = 2
 } mmu_mode_t;
 
-typedef uint32 pagemode_t;
+typedef uint32_t pagemode_t;
 
 typedef struct vtlb {
     vaddr_t va;
     paddr_t ha;
-    uint64 flags;
+    uint64_t flags;
     uint guest_order;
     uint order;
     uint access;
@@ -92,7 +92,7 @@ typedef struct hax_mmu {
     bool igo; /* Is global optimized */
 } hax_mmu_t;
 
-uint64 vtlb_get_cr3(struct vcpu_t *vcpu);
+uint64_t vtlb_get_cr3(struct vcpu_t *vcpu);
 
 void vcpu_invalidate_tlb(struct vcpu_t *vcpu, bool global);
 void vcpu_invalidate_tlb_addr(struct vcpu_t *vcpu, vaddr_t va);
@@ -103,12 +103,12 @@ void vcpu_vtlb_free(struct vcpu_t *vcpu);
 bool handle_vtlb(struct vcpu_t *vcpu);
 
 uint vcpu_translate(struct vcpu_t *vcpu, vaddr_t va, uint access, paddr_t *pa,
-                    uint64 *len, bool update);
+                    uint64_t *len, bool update);
 
-uint32 vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
-                               uint32 dst_buflen, uint32 size, uint flag);
-uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
-                                uint32 dst_buflen, const void *src, uint32 size,
+uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
+                               uint32_t dst_buflen, uint32_t size, uint flag);
+uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
+                                uint32_t dst_buflen, const void *src, uint32_t size,
                                 uint flag);
 
 #ifdef CONFIG_HAX_EPT2
@@ -126,7 +126,7 @@ uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
  * Returns 0 on success, or one of the following error codes:
  * -ENOMEM: Memory allocation/mapping error.
  */
-int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64 gva, uint8 *buf,
+int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64_t gva, uint8_t *buf,
                            int len);
 #endif  // CONFIG_HAX_EPT2
 

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -84,7 +84,7 @@ static void vcpu_ack_intr(struct vcpu_t *vcpu, uint8 vector)
     uint8 offset = vector % 32;
     uint8 nr_word = vector / 32;
 
-    ASSERT(intr_pending[nr_word] & (1 << offset));
+    assert(intr_pending[nr_word] & (1 << offset));
 
     intr_pending[nr_word] &= ~(1 << offset);
     --vcpu->nr_pending_intrs;

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -37,10 +37,10 @@
  * Get highest pending interrupt vector
  * return HAX_INVALID_INTR_VECTOR when no pending
  */
-uint32 vcpu_get_pending_intrs(struct vcpu_t *vcpu)
+uint32_t vcpu_get_pending_intrs(struct vcpu_t *vcpu)
 {
-    uint32 offset, vector;
-    uint32 *intr_pending = vcpu->intr_pending;
+    uint32_t offset, vector;
+    uint32_t *intr_pending = vcpu->intr_pending;
     int i;
 
     if (!vcpu->nr_pending_intrs)
@@ -56,16 +56,16 @@ uint32 vcpu_get_pending_intrs(struct vcpu_t *vcpu)
     if (i < 0)
         return HAX_INVALID_INTR_VECTOR;
 
-    vector = (uint8) (i * 32 + offset);
+    vector = (uint8_t) (i * 32 + offset);
     return vector;
 }
 
 /* Set pending interrupts from userspace in the bitmap */
-void hax_set_pending_intr(struct vcpu_t *vcpu, uint8 vector)
+void hax_set_pending_intr(struct vcpu_t *vcpu, uint8_t vector)
 {
-    uint32 *intr_pending = vcpu->intr_pending;
-    uint8 offset = vector % 32;
-    uint8 nr_word = vector / 32;
+    uint32_t *intr_pending = vcpu->intr_pending;
+    uint8_t offset = vector % 32;
+    uint8_t nr_word = vector / 32;
 
     if (intr_pending[nr_word] & (1 << offset)) {
         hax_debug("vector :%d is already pending.", vector);
@@ -78,11 +78,11 @@ void hax_set_pending_intr(struct vcpu_t *vcpu, uint8 vector)
 /*
  * Clear the pending irqs after injection.
  */
-static void vcpu_ack_intr(struct vcpu_t *vcpu, uint8 vector)
+static void vcpu_ack_intr(struct vcpu_t *vcpu, uint8_t vector)
 {
-    uint32 *intr_pending = vcpu->intr_pending;
-    uint8 offset = vector % 32;
-    uint8 nr_word = vector / 32;
+    uint32_t *intr_pending = vcpu->intr_pending;
+    uint8_t offset = vector % 32;
+    uint8_t nr_word = vector / 32;
 
     assert(intr_pending[nr_word] & (1 << offset));
 
@@ -94,9 +94,9 @@ static void vcpu_ack_intr(struct vcpu_t *vcpu, uint8 vector)
 /* Do the real injection operation for virtual external interrrupts
  * caller must ensure the vcpu is ready for accepting the interrupt
  */
-static void hax_inject_intr(struct vcpu_t *vcpu, uint8 vector)
+static void hax_inject_intr(struct vcpu_t *vcpu, uint8_t vector)
 {
-    uint32 intr_info;
+    uint32_t intr_info;
     intr_info = (1 << 31) | vector;
     vmwrite(vcpu, VMX_ENTRY_INTERRUPT_INFO, intr_info);
     vcpu_ack_intr(vcpu, vector);
@@ -120,7 +120,7 @@ static void hax_enable_intr_window(struct vcpu_t *vcpu)
 uint hax_intr_is_blocked(struct vcpu_t *vcpu)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint32 intr_status;
+    uint32_t intr_status;
 
     if (!(state->_eflags & EFLAGS_IF))
         return 1;
@@ -136,13 +136,13 @@ uint hax_intr_is_blocked(struct vcpu_t *vcpu)
  */
 void hax_handle_idt_vectoring(struct vcpu_t *vcpu)
 {
-    uint8 vector;
-    uint32 idt_vec = vmread(vcpu, VM_EXIT_INFO_IDT_VECTORING);
+    uint8_t vector;
+    uint32_t idt_vec = vmread(vcpu, VM_EXIT_INFO_IDT_VECTORING);
 
     if (idt_vec & 0x80000000) {
         if (!(idt_vec & 0x700)) {
             /* One ext interrupt is pending ? Re-inject it ? */
-            vector = (uint8) (idt_vec & 0xff);
+            vector = (uint8_t) (idt_vec & 0xff);
             hax_set_pending_intr(vcpu, vector);
             hax_debug("extern interrupt is vectoring....vector:%d\n", vector);
         } else {
@@ -159,8 +159,8 @@ void hax_handle_idt_vectoring(struct vcpu_t *vcpu)
  */
 void vcpu_inject_intr(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
-    uint32 vector;
-    uint32 intr_info;
+    uint32_t vector;
+    uint32_t intr_info;
 
     intr_info = vmread(vcpu, VMX_ENTRY_INTERRUPT_INFO);
     vector = vcpu_get_pending_intrs(vcpu);
@@ -176,10 +176,10 @@ void vcpu_inject_intr(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 /* According the to SDM to check whether the pending vector and injecting vector
  * can generate a double fault.
  */
-static int is_double_fault(uint8 first_vec, uint8 second_vec)
+static int is_double_fault(uint8_t first_vec, uint8_t second_vec)
 {
-    uint32 exc_bitmap1 = 0x7c01u;
-    uint32 exc_bitmap2 = 0x3c01u;
+    uint32_t exc_bitmap1 = 0x7c01u;
+    uint32_t exc_bitmap2 = 0x3c01u;
 
     if (is_extern_interrupt(first_vec))
         return 0;
@@ -194,18 +194,18 @@ static int is_double_fault(uint8 first_vec, uint8 second_vec)
 /*
  * Inject faults or exceptions to the virtual processor .
  */
-void hax_inject_exception(struct vcpu_t *vcpu, uint8 vector, uint32 error_code)
+void hax_inject_exception(struct vcpu_t *vcpu, uint8_t vector, uint32_t error_code)
 {
-    uint32 intr_info = 0;
-    uint8 first_vec;
-    uint32 vect_info = vmx(vcpu, exit_idt_vectoring);
-    uint32 exit_instr_length = vmx(vcpu, exit_instr_length);
+    uint32_t intr_info = 0;
+    uint8_t first_vec;
+    uint32_t vect_info = vmx(vcpu, exit_idt_vectoring);
+    uint32_t exit_instr_length = vmx(vcpu, exit_instr_length);
 
     if (vcpu->event_injected == 1)
         hax_debug("Event is injected already!!:\n");
 
     if (vect_info & INTR_INFO_VALID_MASK) {
-        first_vec = (uint8) (vect_info & INTR_INFO_VECTOR_MASK);
+        first_vec = (uint8_t) (vect_info & INTR_INFO_VECTOR_MASK);
         if (is_double_fault(first_vec, vector)) {
             intr_info = (1 << 31) | (1 << 11) | (EXCEPTION << 8)
                         | VECTOR_DF;

--- a/core/memory.c
+++ b/core/memory.c
@@ -38,7 +38,7 @@
 #endif  // CONFIG_HAX_EPT2
 
 #ifdef CONFIG_HAX_EPT2
-static int handle_alloc_ram(struct vm_t *vm, uint64 start_uva, uint64 size)
+static int handle_alloc_ram(struct vm_t *vm, uint64_t start_uva, uint64_t size)
 {
     int ret;
     hax_ramblock *block;
@@ -232,12 +232,12 @@ static struct hax_vcpu_mem *get_pmem_range(struct vm_t *vm, uint64_t va)
 }
 
 #ifdef CONFIG_HAX_EPT2
-static int handle_set_ram(struct vm_t *vm, uint64 start_gpa, uint64 size,
-                          uint64 start_uva, uint32 flags)
+static int handle_set_ram(struct vm_t *vm, uint64_t start_gpa, uint64_t size,
+                          uint64_t start_uva, uint32_t flags)
 {
     bool unmap = flags & HAX_RAM_INFO_INVALID;
     hax_gpa_space *gpa_space;
-    uint64 start_gfn, npages;
+    uint64_t start_gfn, npages;
     int ret;
     hax_ept_tree *ept_tree;
 
@@ -272,7 +272,7 @@ static int handle_set_ram(struct vm_t *vm, uint64 start_gpa, uint64 size,
     memslot_dump_list(gpa_space);
 
     ept_tree = &vm->ept_tree;
-    if (!hax_test_and_clear_bit(0, (uint64 *)&ept_tree->invept_pending)) {
+    if (!hax_test_and_clear_bit(0, (uint64_t *)&ept_tree->invept_pending)) {
         // INVEPT pending flag was set
         hax_info("%s: Invoking INVEPT for VM #%d\n", __func__, vm->vm_id);
         invept(vm, EPT_INVEPT_SINGLE_CONTEXT);

--- a/core/memory.c
+++ b/core/memory.c
@@ -287,8 +287,8 @@ int hax_vm_set_ram(struct vm_t *vm, struct hax_set_ram_info *info)
     return handle_set_ram(vm, info->pa_start, info->size, info->va,
                           info->flags);
 #else  // !CONFIG_HAX_EPT2
-    int num = info->size >> page_shift;
-    uint64_t gpfn = info->pa_start >> page_shift;
+    int num = info->size >> HAX_PAGE_SHIFT;
+    uint64_t gpfn = info->pa_start >> HAX_PAGE_SHIFT;
     uint64_t cur_va = info->va;
     bool is_unmap = info->flags & HAX_RAM_INFO_INVALID;
     bool is_readonly = info->flags & HAX_RAM_INFO_ROM;
@@ -348,7 +348,7 @@ int hax_vm_set_ram(struct vm_t *vm, struct hax_set_ram_info *info)
         if (!hax_core_set_p2m(vm, gpfn, hpfn, hva, info->flags)) {
             return -ENOMEM;
         }
-        if (!ept_set_pte(vm, gpfn << page_shift, hpfn << page_shift, emt, perm,
+        if (!ept_set_pte(vm, gpfn << HAX_PAGE_SHIFT, hpfn << HAX_PAGE_SHIFT, emt, perm,
                          &epte_modified)) {
             hax_error("ept_set_pte() failed at gpfn 0x%llx hpfn 0x%llx\n", gpfn,
                       hpfn);
@@ -393,7 +393,7 @@ int hax_vcpu_setup_hax_tunnel(struct vcpu_t *cv, struct hax_tunnel_info *info)
     // The tunnel and iobuf are always set together.
     if (cv->tunnel && cv->iobuf_vcpumem) {
         hax_info("setup hax tunnel request for already setup one\n");
-        info->size = PAGE_SIZE;
+        info->size = HAX_PAGE_SIZE;
         info->va = cv->tunnel_vcpumem->uva;
         info->io_va = cv->iobuf_vcpumem->uva;
         return 0;
@@ -407,7 +407,7 @@ int hax_vcpu_setup_hax_tunnel(struct vcpu_t *cv, struct hax_tunnel_info *info)
     if (!cv->iobuf_vcpumem)
         goto error;
 
-    ret = hax_setup_vcpumem(cv->tunnel_vcpumem, 0, PAGE_SIZE, 0);
+    ret = hax_setup_vcpumem(cv->tunnel_vcpumem, 0, HAX_PAGE_SIZE, 0);
     if (ret < 0)
         goto error;
 
@@ -417,7 +417,7 @@ int hax_vcpu_setup_hax_tunnel(struct vcpu_t *cv, struct hax_tunnel_info *info)
 
     info->va = cv->tunnel_vcpumem->uva;
     info->io_va = cv->iobuf_vcpumem->uva;
-    info->size = PAGE_SIZE;
+    info->size = HAX_PAGE_SIZE;
     set_vcpu_tunnel(cv, (struct hax_tunnel *)cv->tunnel_vcpumem->kva,
                     (uint8_t *)cv->iobuf_vcpumem->kva);
     return 0;

--- a/core/memory.c
+++ b/core/memory.c
@@ -329,14 +329,14 @@ int hax_vm_set_ram(struct vm_t *vm, struct hax_set_ram_info *info)
                  */
                 return -ENOMEM;
             }
-#if defined(__MACH__)
-#ifdef __x86_64__
+#if defined(HAX_PLATFORM_DARWIN)
+#ifdef HAX_ARCH_X86_64
             hva = (uint64_t)pmem->kva + (cur_va - pmem->uva);
 #else
             hva = (uint64_t)(uint32_t)pmem->kva + (cur_va - pmem->uva);
 #endif
-#else   // __MACH
-#if defined(_WIN64)
+#else   // !HAX_PLATFORM_DARWIN
+#ifdef HAX_ARCH_X86_64
             hva = (uint64_t)pmem->kva + (cur_va - pmem->uva);
 #else
             hva = 0;

--- a/core/memslot.c
+++ b/core/memslot.c
@@ -49,16 +49,16 @@ enum route {
     MAPPING_INVALID
 };
 
-typedef int (*MEMSLOT_PROCESS)(hax_memslot *, hax_memslot *, uint8 *);
+typedef int (*MEMSLOT_PROCESS)(hax_memslot *, hax_memslot *, uint8_t *);
 
 typedef struct memslot_mapping {
-    uint8 callback;
-    uint64 start_gfn;
-    uint64 npages;
-    uint64 old_uva;
-    uint32 old_flags;
-    uint64 new_uva;
-    uint32 new_flags;
+    uint8_t callback;
+    uint64_t start_gfn;
+    uint64_t npages;
+    uint64_t old_uva;
+    uint32_t old_flags;
+    uint64_t new_uva;
+    uint32_t new_flags;
 } memslot_mapping;
 
 static void memslot_init(hax_memslot *dest, hax_memslot *src);
@@ -72,22 +72,22 @@ static void memslot_union(hax_memslot *dest, hax_memslot *src);
 static void memslot_overlap_front(hax_memslot *dest, hax_memslot *src);
 static void memslot_overlap_rear(hax_memslot *dest, hax_memslot *src);
 static hax_memslot * memslot_append_rest(hax_memslot *dest, hax_memslot *src);
-static bool memslot_is_valid(uint32 flags);
+static bool memslot_is_valid(uint32_t flags);
 static bool memslot_is_same_type(hax_memslot *dest, hax_memslot *src);
 static bool memslot_is_inner(hax_memslot *dest, hax_memslot *src,
                              hax_gpa_space *gpa_space);
 static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
-                                           uint8 *state);
+                                           uint8_t *state);
 static int memslot_process_start_same_type(hax_memslot *dest, hax_memslot *src,
-                                           uint8 *state);
+                                           uint8_t *state);
 static int memslot_process_start_invalid(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state);
+                                         uint8_t *state);
 static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state);
+                                         uint8_t *state);
 static int memslot_process_end_same_type(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state);
+                                         uint8_t *state);
 static int memslot_process_end_invalid(hax_memslot *dest, hax_memslot *src,
-                                       uint8 *state);
+                                       uint8_t *state);
 static int memslot_list_enqueue(hax_list_head *memslot_list, hax_memslot *dest);
 static void memslot_list_clear(hax_list_head *memslot_list);
 static void mapping_broadcast(hax_list_head *listener_list,
@@ -153,8 +153,8 @@ void memslot_dump_list(hax_gpa_space *gpa_space)
     hax_info("memslot dump ends!\n");
 }
 
-int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
-                        uint64 npages, uint64 uva, uint32 flags)
+int memslot_set_mapping(hax_gpa_space *gpa_space, uint64_t start_gfn,
+                        uint64_t npages, uint64_t uva, uint32_t flags)
 {
     hax_memslot memslot, *src = NULL, *dest = &memslot, *m = NULL;
     hax_ramblock *block = NULL;
@@ -162,7 +162,7 @@ int memslot_set_mapping(hax_gpa_space *gpa_space, uint64 start_gfn,
     hax_list_head snapshot;
     int ret = 0;
     bool is_valid = false, is_found = false;
-    uint8 route = 0, state = 0;
+    uint8_t route = 0, state = 0;
 
     hax_info("%s: start_gfn=0x%llx, npages=0x%llx, uva=0x%llx, flags=0x%x\n",
              __func__, start_gfn, npages, uva, flags);
@@ -290,7 +290,7 @@ out:
     return ret;
 }
 
-hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64 gfn)
+hax_memslot * memslot_find(hax_gpa_space *gpa_space, uint64_t gfn)
 {
     hax_memslot *memslot = NULL;
 
@@ -409,7 +409,7 @@ static inline hax_memslot * memslot_append_rest(hax_memslot *dest,
     return rest;
 }
 
-static inline bool memslot_is_valid(uint32 flags)
+static inline bool memslot_is_valid(uint32_t flags)
 {
     return (flags & HAX_MEMSLOT_INVALID) != HAX_MEMSLOT_INVALID;
 }
@@ -471,7 +471,7 @@ static bool memslot_is_inner(hax_memslot *dest, hax_memslot *src,
 // Figure 1: Memory slot process start (primary node)
 
 static int memslot_process_start_diff_type(hax_memslot *dest, hax_memslot *src,
-                                           uint8 *state)
+                                           uint8_t *state)
 {
     int ret = 0;
 
@@ -529,7 +529,7 @@ out:
 }
 
 static int memslot_process_start_same_type(hax_memslot *dest, hax_memslot *src,
-                                           uint8 *state)
+                                           uint8_t *state)
 {
     int ret = 0;
 
@@ -555,7 +555,7 @@ out:
 }
 
 static int memslot_process_start_invalid(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state)
+                                         uint8_t *state)
 {
     int ret = 0;
 
@@ -616,7 +616,7 @@ out:
 //   function memslot_is_inner).
 
 static int memslot_process_end_diff_type(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state)
+                                         uint8_t *state)
 {
     int ret = 0;
 
@@ -647,7 +647,7 @@ out:
 }
 
 static int memslot_process_end_same_type(hax_memslot *dest, hax_memslot *src,
-                                         uint8 *state)
+                                         uint8_t *state)
 {
     hax_memslot *prev = NULL;
 
@@ -670,7 +670,7 @@ static int memslot_process_end_same_type(hax_memslot *dest, hax_memslot *src,
 }
 
 static int memslot_process_end_invalid(hax_memslot *dest, hax_memslot *src,
-                                       uint8 *state)
+                                       uint8_t *state)
 {
     if (dest->base_gfn + dest->npages == src->base_gfn)
         // [1]

--- a/core/memslot.c
+++ b/core/memslot.c
@@ -37,6 +37,13 @@
 
 #define SAFE_CALL(f) if ((f) != NULL) (f)
 
+#ifndef min
+#define min(a, b) (((a) < (b)) ? (a) : (b)) 
+#endif
+#ifndef max
+#define max(a, b) (((a) > (b)) ? (a) : (b)) 
+#endif
+
 enum callback {
     MAPPING_ADDED = 1,
     MAPPING_REMOVED,

--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -589,7 +589,7 @@ uint32_t pw_perform_page_walk(
     uint32_t pml4te_index, pdpte_index, pde_index, pte_index;
     bool is_write, is_user;
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     bool is_kernel;
 #endif
 #endif // !CONFIG_HAX_EPT2
@@ -605,7 +605,7 @@ uint32_t pw_perform_page_walk(
     is_write = access & TF_WRITE;
     is_user  = access & TF_USER;
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     is_kernel = (virt_addr >= KERNEL_BASE) ? true : false;
 #endif
 #endif // !CONFIG_HAX_EPT2
@@ -623,7 +623,7 @@ uint32_t pw_perform_page_walk(
                                            pml4t_gpa >> PG_ORDER_4K,
                                            &pml4t_kmap, NULL);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             pml4t_hva = hax_map_gpfn(vcpu->vm, pml4t_gpa >> 12, is_kernel, cr3,
                                      1);
 #else
@@ -659,7 +659,7 @@ uint32_t pw_perform_page_walk(
                                       pdpt_gpa >> PG_ORDER_4K,
                                       &pdpt_kmap, NULL);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         pdpt_hva = hax_map_gpfn(vcpu->vm, pdpt_gpa >> 12, is_kernel, cr3, 1);
 #else
         pdpt_hva = hax_map_gpfn(vcpu->vm, pdpt_gpa >> 12);
@@ -734,7 +734,7 @@ uint32_t pw_perform_page_walk(
     pd_hva = gpa_space_map_page(&vcpu->vm->gpa_space, pd_gpa >> PG_ORDER_4K,
                                 &pd_kmap, NULL);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     pd_hva = hax_map_gpfn(vcpu->vm, pd_gpa >> 12, is_kernel, cr3, 2);
 #else
     pd_hva = hax_map_gpfn(vcpu->vm, pd_gpa >> 12);
@@ -812,7 +812,7 @@ uint32_t pw_perform_page_walk(
     pt_hva = gpa_space_map_page(&vcpu->vm->gpa_space, pt_gpa >> 12, &pt_kmap,
                                 NULL);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     pt_hva = hax_map_gpfn(vcpu->vm, pt_gpa >> 12, is_kernel, cr3, 1);
 #else
     pt_hva = hax_map_gpfn(vcpu->vm, pt_gpa >> 12);
@@ -881,7 +881,7 @@ out:
     if (pt_hva    != NULL)
         gpa_space_unmap_page(&vcpu->vm->gpa_space, &pt_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     if (pml4t_hva != NULL)
         hax_unmap_gpfn(vcpu->vm, pml4t_hva, pml4t_gpa >> 12);
     if (pdpt_hva  != NULL)

--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -40,7 +40,7 @@
 typedef union PW_PAGE_ENTRY_U {
     union {
         struct {
-            uint32 present          : 1,
+            uint32_t present          : 1,
                    writable         : 1,
                    user             : 1,
                    pwt              : 1,
@@ -52,11 +52,11 @@ typedef union PW_PAGE_ENTRY_U {
                    available        : 3,
                    addr_base        : 20;
         } bits;
-        uint32 val;
+        uint32_t val;
     } non_pae_entry;
     union {
         struct {
-            uint32 present          : 1,
+            uint32_t present          : 1,
                    writable         : 1,
                    user             : 1,
                    pwt              : 1,
@@ -67,36 +67,36 @@ typedef union PW_PAGE_ENTRY_U {
                    global           : 1,
                    available        : 3,
                    addr_base_low    : 20;
-            uint32 addr_base_high   : 20,
+            uint32_t addr_base_high   : 20,
                    avl_or_res       : 11,
                    exb_or_res       : 1;
         } bits;
-        uint64 val;
+        uint64_t val;
     } pae_lme_entry;
 } PW_PAGE_ENTRY;
 
 typedef union PW_PFEC_U {
     struct {
-        uint32 present              : 1,
+        uint32_t present              : 1,
                is_write             : 1,
                is_user              : 1,
                is_reserved          : 1,
                is_fetch             : 1,
                reserved             : 27;
-        uint32 reserved_high;
+        uint32_t reserved_high;
     } bits;
-    uint64 val;
+    uint64_t val;
 } PW_PFEC;
 
 #define PW_NUM_OF_TABLE_ENTRIES_IN_PAE_MODE 512
 #define PW_NUM_OF_TABLE_ENTRIES_IN_NON_PAE_MODE 1024
-#define PW_INVALID_INDEX ((uint32)(~(0)));
+#define PW_INVALID_INDEX ((uint32_t)(~(0)));
 #define PW_PAE_ENTRY_INCREMENT 8
 #define PW_NON_PAE_ENTRY_INCREMENT 4
 #define PW_PDPTE_INDEX_MASK_IN_32_BIT_ADDR 0xc0000000
 #define PW_PDPTE_INDEX_SHIFT 30
-#define PW_PDPTE_INDEX_MASK_IN_64_BIT_ADDR ((uint64)0x0000007fc0000000)
-#define PW_PML4TE_INDEX_MASK ((uint64)0x0000ff8000000000)
+#define PW_PDPTE_INDEX_MASK_IN_64_BIT_ADDR ((uint64_t)0x0000007fc0000000)
+#define PW_PML4TE_INDEX_MASK ((uint64_t)0x0000ff8000000000)
 #define PW_PML4TE_INDEX_SHIFT 39
 #define PW_PDE_INDEX_MASK_IN_PAE_MODE 0x3fe00000
 #define PW_PDE_INDEX_SHIFT_IN_PAE_MODE 21
@@ -108,13 +108,13 @@ typedef union PW_PFEC_U {
 #define PW_PDPT_ALIGNMENT 32
 #define PW_TABLE_SHIFT 12
 #define PW_HIGH_ADDRESS_SHIFT 32
-#define PW_2M_PAE_PDE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32)0x1fe000)
-#define PW_4M_NON_PAE_PDE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32)0x3fe000)
-#define PW_1G_PAE_PDPTE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32)0x3fffe000)
+#define PW_2M_PAE_PDE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32_t)0x1fe000)
+#define PW_4M_NON_PAE_PDE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32_t)0x3fe000)
+#define PW_1G_PAE_PDPTE_RESERVED_BITS_IN_ENTRY_LOW_MASK ((uint32_t)0x3fffe000)
 
-uint32 pw_reserved_bits_high_mask;
+uint32_t pw_reserved_bits_high_mask;
 
-static inline uint64 pw_retrieve_table_from_cr3(uint64 cr3, bool is_pae,
+static inline uint64_t pw_retrieve_table_from_cr3(uint64_t cr3, bool is_pae,
                                                 bool is_lme)
 {
     if (!is_pae || is_lme)
@@ -123,23 +123,23 @@ static inline uint64 pw_retrieve_table_from_cr3(uint64 cr3, bool is_pae,
     return ALIGN_BACKWARD(cr3, PW_PDPT_ALIGNMENT);
 }
 
-static void pw_retrieve_indices(IN uint64 virtual_address, IN bool is_pae,
-                                IN bool is_lme, OUT uint32 *pml4te_index,
-                                OUT uint32 *pdpte_index, OUT uint32 *pde_index,
-                                OUT uint32 *pte_index)
+static void pw_retrieve_indices(IN uint64_t virtual_address, IN bool is_pae,
+                                IN bool is_lme, OUT uint32_t *pml4te_index,
+                                OUT uint32_t *pdpte_index, OUT uint32_t *pde_index,
+                                OUT uint32_t *pte_index)
 {
-    uint32 virtual_address_low_32_bit = (uint32)virtual_address;
+    uint32_t virtual_address_low_32_bit = (uint32_t)virtual_address;
 
     if (is_pae) {
         if (is_lme) {
-            uint64 pml4te_index_tmp = (virtual_address & PW_PML4TE_INDEX_MASK)
+            uint64_t pml4te_index_tmp = (virtual_address & PW_PML4TE_INDEX_MASK)
                                       >> PW_PML4TE_INDEX_SHIFT;
-            uint64 pdpte_index_tmp =
+            uint64_t pdpte_index_tmp =
                     (virtual_address & PW_PDPTE_INDEX_MASK_IN_64_BIT_ADDR)
                     >> PW_PDPTE_INDEX_SHIFT;
 
-            *pml4te_index = (uint32)pml4te_index_tmp;
-            *pdpte_index = (uint32)pdpte_index_tmp;
+            *pml4te_index = (uint32_t)pml4te_index_tmp;
+            *pdpte_index = (uint32_t)pdpte_index_tmp;
         } else {
             *pml4te_index = PW_INVALID_INDEX;
             *pdpte_index = (virtual_address_low_32_bit &
@@ -168,14 +168,14 @@ static void pw_retrieve_indices(IN uint64 virtual_address, IN bool is_pae,
 }
 
 static PW_PAGE_ENTRY * pw_retrieve_table_entry(
-        struct vcpu_t *vcpu, void *table_hva, uint32 entry_index, bool is_pae)
+        struct vcpu_t *vcpu, void *table_hva, uint32_t entry_index, bool is_pae)
 {
-    uint64 entry_hva;
+    uint64_t entry_hva;
 
     if (is_pae) {
-        entry_hva = (uint64)table_hva + entry_index * PW_PAE_ENTRY_INCREMENT;
+        entry_hva = (uint64_t)table_hva + entry_index * PW_PAE_ENTRY_INCREMENT;
     } else {
-        entry_hva = (uint64)table_hva
+        entry_hva = (uint64_t)table_hva
                     + entry_index * PW_NON_PAE_ENTRY_INCREMENT;
     }
 
@@ -186,9 +186,9 @@ static void pw_read_entry_value(
         PW_PAGE_ENTRY *fill_to, PW_PAGE_ENTRY *fill_from, bool is_pae)
 {
     if (is_pae) {
-        volatile uint64 *original_value_ptr = (volatile uint64 *)fill_from;
-        uint64 value1 = *original_value_ptr;
-        uint64 value2 = *original_value_ptr;
+        volatile uint64_t *original_value_ptr = (volatile uint64_t *)fill_from;
+        uint64_t value1 = *original_value_ptr;
+        uint64_t value2 = *original_value_ptr;
 
         while (value1 != value2) {
             value1 = value2;
@@ -407,26 +407,26 @@ static bool pw_is_fetch_access_permitted(
     return !pte->pae_lme_entry.bits.exb_or_res;
 }
 
-static uint64 pw_retrieve_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae)
+static uint64_t pw_retrieve_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae)
 {
     assert(entry->non_pae_entry.bits.present);
     if (is_pae) {
-        uint32 addr_low = entry->pae_lme_entry.bits.addr_base_low
+        uint32_t addr_low = entry->pae_lme_entry.bits.addr_base_low
                           << PW_TABLE_SHIFT;
-        uint32 addr_high = entry->pae_lme_entry.bits.addr_base_high;
-        return ((uint64)addr_high << PW_HIGH_ADDRESS_SHIFT) | addr_low;
+        uint32_t addr_high = entry->pae_lme_entry.bits.addr_base_high;
+        return ((uint64_t)addr_high << PW_HIGH_ADDRESS_SHIFT) | addr_low;
     }
 
-    // Must convert the uint32 bit-field to uint64 before the shift. Otherwise,
+    // Must convert the uint32_t bit-field to uint64_t before the shift. Otherwise,
     // on Mac the shift result will be sign-extended to 64 bits (Clang bug?),
     // yielding invalid GPAs such as 0xffffffff801c8000.
-    return (uint64)entry->non_pae_entry.bits.addr_base << PW_TABLE_SHIFT;
+    return (uint64_t)entry->non_pae_entry.bits.addr_base << PW_TABLE_SHIFT;
 }
 
-static uint64 pw_retrieve_big_page_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae,
+static uint64_t pw_retrieve_big_page_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae,
                                              bool is_1gb)
 {
-    uint64 base = pw_retrieve_phys_addr(entry, is_pae);
+    uint64_t base = pw_retrieve_phys_addr(entry, is_pae);
 
     // Clean offset bits
     if (is_pae) {
@@ -440,20 +440,20 @@ static uint64 pw_retrieve_big_page_phys_addr(PW_PAGE_ENTRY *entry, bool is_pae,
     return ALIGN_BACKWARD(base, PAGE_SIZE_4M);
 }
 
-static uint32 pw_get_big_page_offset(uint64 virtual_address, bool is_pae,
+static uint32_t pw_get_big_page_offset(uint64_t virtual_address, bool is_pae,
                                      bool is_1gb)
 {
     if (is_pae) {
         if (is_1gb) {
             // Take only 30 LSBs
-            return (uint32)(virtual_address & PAGE_1GB_MASK);
+            return (uint32_t)(virtual_address & PAGE_1GB_MASK);
         }
         // Take only 21 LSBs
-        return (uint32)(virtual_address & PAGE_2MB_MASK);
+        return (uint32_t)(virtual_address & PAGE_2MB_MASK);
     }
 
     // Take 22 LSBs
-    return (uint32)(virtual_address & PAGE_4MB_MASK);
+    return (uint32_t)(virtual_address & PAGE_4MB_MASK);
 }
 
 static void pw_update_ad_bits_in_entry(PW_PAGE_ENTRY *native_entry,
@@ -468,8 +468,8 @@ static void pw_update_ad_bits_in_entry(PW_PAGE_ENTRY *native_entry,
         new_native_value->non_pae_entry.val) {
         hax_cmpxchg64(old_native_value->non_pae_entry.val,
                       new_native_value->non_pae_entry.val,
-                      (volatile uint64 *)native_entry);
-        // hw_interlocked_compare_exchange((INT32 volatile *)native_entry,
+                      (volatile uint64_t *)native_entry);
+        // hw_interlocked_compare_exchange((int32_t volatile *)native_entry,
         //                                 old_native_value->non_pae_entry.val,
         //                                 new_native_value->non_pae_entry.val);
         // The result is not checked. If the cmpxchg has failed, it means that
@@ -560,24 +560,24 @@ static void pw_update_ad_bits(
     pw_update_ad_bits_in_entry(guest_space_pte, &pte_before_update, pte);
 }
 
-uint32 pw_perform_page_walk(
-        IN struct vcpu_t *vcpu, IN uint64 virt_addr, IN uint32 access,
-        OUT uint64 *gpa_out, OUT uint *order, IN bool set_ad_bits,
+uint32_t pw_perform_page_walk(
+        IN struct vcpu_t *vcpu, IN uint64_t virt_addr, IN uint32_t access,
+        OUT uint64_t *gpa_out, OUT uint *order, IN bool set_ad_bits,
         IN bool is_fetch)
 {
-    uint32 retval = TF_OK;
-    uint64 efer_value = vcpu->state->_efer;
+    uint32_t retval = TF_OK;
+    uint64_t efer_value = vcpu->state->_efer;
     bool is_nxe = ((efer_value & IA32_EFER_XD) != 0);
     bool is_lme = ((efer_value & IA32_EFER_LME) != 0);
-    uint64 cr0 = vcpu->state->_cr0;
-    uint64 cr3 = vcpu->state->_cr3;
-    uint64 cr4 = vcpu->state->_cr4;
+    uint64_t cr0 = vcpu->state->_cr0;
+    uint64_t cr3 = vcpu->state->_cr3;
+    uint64_t cr4 = vcpu->state->_cr4;
     bool is_wp = ((cr0 & CR0_WP) != 0);
     bool is_pae = ((cr4 & CR4_PAE) != 0);
     bool is_pse = ((cr4 & CR4_PSE) != 0);
 
-    uint64 gpa = PW_INVALID_GPA;
-    uint64 first_table;
+    uint64_t gpa = PW_INVALID_GPA;
+    uint64_t first_table;
 
     PW_PAGE_ENTRY *pml4te_ptr, *pdpte_ptr, *pde_ptr, *pte_ptr = NULL;
     PW_PAGE_ENTRY pml4te_val, pdpte_val, pde_val, pte_val;
@@ -585,8 +585,8 @@ uint32 pw_perform_page_walk(
 #ifdef CONFIG_HAX_EPT2
     hax_kmap_user pml4t_kmap, pdpt_kmap, pd_kmap, pt_kmap;
 #endif // CONFIG_HAX_EPT2
-    uint64 pml4t_gpa, pdpt_gpa, pd_gpa, pt_gpa;
-    uint32 pml4te_index, pdpte_index, pde_index, pte_index;
+    uint64_t pml4t_gpa, pdpt_gpa, pd_gpa, pt_gpa;
+    uint32_t pml4te_index, pdpte_index, pde_index, pte_index;
     bool is_write, is_user;
 #ifndef CONFIG_HAX_EPT2
 #if (!defined(__MACH__) && !defined(_WIN64))
@@ -688,8 +688,8 @@ uint32 pw_perform_page_walk(
 
     // 1GB page size
     if (pw_is_1gb_page_pdpte(&pdpte_val)) {
-        uint64 big_page_addr;
-        uint32 offset_in_big_page;
+        uint64_t big_page_addr;
+        uint32_t offset_in_big_page;
 
         *order = PG_ORDER_1G;
         // Retrieve address of the big page in guest space
@@ -762,8 +762,8 @@ uint32 pw_perform_page_walk(
 
     // 2MB, 4MB page size
     if (pw_is_big_page_pde(&pde_val, is_lme, is_pae, is_pse)) {
-        uint64 big_page_addr;
-        uint32 offset_in_big_page = 0;
+        uint64_t big_page_addr;
+        uint32_t offset_in_big_page = 0;
 
         *order = is_pae ? PG_ORDER_2M : PG_ORDER_4M;
 

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1228,7 +1228,7 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
                 EXIT_CONTROL_SAVE_DEBUG_CONTROLS;
 #endif
 
-#ifdef __i386__
+#ifdef HAX_ARCH_X86_32
     if (is_compatible()) {
         exit_ctls = EXIT_CONTROL_HOST_ADDR_SPACE_SIZE | EXIT_CONTROL_LOAD_EFER |
                     EXIT_CONTROL_SAVE_DEBUG_CONTROLS;
@@ -1776,11 +1776,11 @@ static int vcpu_prepare_pae_pdpt(struct vcpu_t *vcpu)
 #else // !CONFIG_HAX_EPT2
     uint64_t gpfn = (cr3 & 0xfffff000) >> PG_ORDER_4K;
     uint8_t *buf, *pdpt;
-#if (defined(__MACH__) || defined(_WIN64))
+#ifdef HAX_ARCH_X86_64
     buf = hax_map_gpfn(vcpu->vm, gpfn);
-#else  // !defined(__MACH__) && !defined(_WIN64), i.e. Win32
+#else  // !HAX_ARCH_X86_64, i.e. HAX_ARCH_X86_32
     buf = hax_map_gpfn(vcpu->vm, gpfn, false, cr3 & 0xfffff000, 1);
-#endif  // defined(__MACH__) || defined(_WIN64)
+#endif  // HAX_ARCH_X86_64
     if (!buf) {
         hax_error("%s: Failed to map guest page frame containing PAE PDPT:"
                   " cr3=0x%llx\n",  __func__, cr3);
@@ -1788,11 +1788,11 @@ static int vcpu_prepare_pae_pdpt(struct vcpu_t *vcpu)
     }
     pdpt = buf + (cr3 & 0xfe0);
     memcpy_s(vcpu->pae_pdptes, pdpt_size, pdpt, pdpt_size);
-#if (defined(__MACH__) || defined(_WIN64))
+#ifdef HAX_ARCH_X86_64
     hax_unmap_gpfn(buf);
-#else  // !defined(__MACH__) && !defined(_WIN64), i.e. Win32
+#else  // !HAX_ARCH_X86_64, i.e. HAX_ARCH_X86_32
     hax_unmap_gpfn(vcpu->vm, buf, gpfn);
-#endif  // defined(__MACH__) || defined(_WIN64)
+#endif  // HAX_ARCH_X86_64
     return 0;
 #endif  // CONFIG_HAX_EPT2
 }

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1984,7 +1984,7 @@ static bool is_mmio_address(struct vcpu_t *vcpu, paddr_t gpa)
 {
     paddr_t hpa;
     if (vtlb_active(vcpu)) {
-        hpa = hax_gpfn_to_hpa(vcpu->vm, gpa >> page_shift);
+        hpa = hax_gpfn_to_hpa(vcpu->vm, gpa >> HAX_PAGE_SHIFT);
         // hax_gpfn_to_hpa() assumes hpa == 0 is invalid
         return !hpa;
     } else {

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -47,7 +47,7 @@
 #include "include/hax_core_interface.h"
 #include "include/hax_driver.h"
 
-uint64 gmsr_list[NR_GMSR] = {
+uint64_t gmsr_list[NR_GMSR] = {
     IA32_STAR,
     IA32_LSTAR,
     IA32_CSTAR,
@@ -55,7 +55,7 @@ uint64 gmsr_list[NR_GMSR] = {
     IA32_KERNEL_GS_BASE
 };
 
-uint64 hmsr_list[NR_HMSR] = {
+uint64_t hmsr_list[NR_HMSR] = {
     IA32_EFER,
     IA32_STAR,
     IA32_LSTAR,
@@ -64,7 +64,7 @@ uint64 hmsr_list[NR_HMSR] = {
     IA32_KERNEL_GS_BASE
 };
 
-uint64 emt64_msr[NR_EMT64MSR] = {
+uint64_t emt64_msr[NR_EMT64MSR] = {
     IA32_STAR,
     IA32_LSTAR,
     IA32_CSTAR,
@@ -72,7 +72,7 @@ uint64 emt64_msr[NR_EMT64MSR] = {
     IA32_KERNEL_GS_BASE
 };
 
-extern uint32 pw_reserved_bits_high_mask;
+extern uint32_t pw_reserved_bits_high_mask;
 
 static void vcpu_init(struct vcpu_t *vcpu);
 static void vcpu_prepare(struct vcpu_t *vcpu);
@@ -105,22 +105,22 @@ static int null_handler(struct vcpu_t *vcpu, struct hax_tunnel *hun);
 static void advance_rip(struct vcpu_t *vcpu);
 static void handle_machine_check(struct vcpu_t *vcpu);
 
-static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 eax, uint32 ecx);
+static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t eax, uint32_t ecx);
 static void handle_mem_fault(struct vcpu_t *vcpu, struct hax_tunnel *htun);
-static void check_flush(struct vcpu_t *vcpu, uint32 bits);
+static void check_flush(struct vcpu_t *vcpu, uint32_t bits);
 static void vmwrite_efer(struct vcpu_t *vcpu);
 
-static int handle_msr_read(struct vcpu_t *vcpu, uint32 msr, uint64 *val);
-static int handle_msr_write(struct vcpu_t *vcpu, uint32 msr, uint64 val);
+static int handle_msr_read(struct vcpu_t *vcpu, uint32_t msr, uint64_t *val);
+static int handle_msr_write(struct vcpu_t *vcpu, uint32_t msr, uint64_t val);
 static void handle_cpuid(struct vcpu_t *vcpu, struct hax_tunnel *htun);
-static void vcpu_dump(struct vcpu_t *vcpu, uint32 mask, const char *caption);
+static void vcpu_dump(struct vcpu_t *vcpu, uint32_t mask, const char *caption);
 static void vcpu_state_dump(struct vcpu_t *vcpu);
 static void vcpu_enter_fpu_state(struct vcpu_t *vcpu);
 
-static int vcpu_set_apic_base(struct vcpu_t *vcpu, uint64 val);
+static int vcpu_set_apic_base(struct vcpu_t *vcpu, uint64_t val);
 static bool vcpu_is_bsp(struct vcpu_t *vcpu);
 
-static uint32 get_seg_present(uint32 seg)
+static uint32_t get_seg_present(uint32_t seg)
 {
     mword ldtr_base;
     struct seg_desc_t *seg_desc;
@@ -138,7 +138,7 @@ static void fake_seg_gs_entry(struct hstate *hstate)
 {
     mword ldtr_base;
     struct seg_desc_t *seg_desc = NULL;
-    uint16 seg = hstate->gs;
+    uint16_t seg = hstate->gs;
 
     ldtr_base = get_kernel_ldtr_base();
     seg_desc = (struct seg_desc_t *)ldtr_base + (seg >> 3);
@@ -149,8 +149,8 @@ static void fake_seg_gs_entry(struct hstate *hstate)
     seg_desc->_raw = 0;
 }
 
-static void get_segment_desc_t(segment_desc_t *sdt, uint32 s, uint64 b,
-                               uint32 l, uint32 a)
+static void get_segment_desc_t(segment_desc_t *sdt, uint32_t s, uint64_t b,
+                               uint32_t l, uint32_t a)
 {
     sdt->selector = s;
     sdt->base = b;
@@ -158,23 +158,23 @@ static void get_segment_desc_t(segment_desc_t *sdt, uint32 s, uint64 b,
     sdt->ar = a;
 }
 
-static inline void set_gdt(struct vcpu_state_t *state, uint64 base,
-                           uint64 limit)
+static inline void set_gdt(struct vcpu_state_t *state, uint64_t base,
+                           uint64_t limit)
 {
     state->_gdt.base = base;
     state->_gdt.limit = limit;
 }
 
-static inline void set_idt(struct vcpu_state_t *state, uint64 base,
-                           uint64 limit)
+static inline void set_idt(struct vcpu_state_t *state, uint64_t base,
+                           uint64_t limit)
 {
     state->_idt.base = base;
     state->_idt.limit = limit;
 }
 
-static uint64 vcpu_read_cr(struct vcpu_state_t *state, uint32 n)
+static uint64_t vcpu_read_cr(struct vcpu_state_t *state, uint32_t n)
 {
-    uint64 val = 0;
+    uint64_t val = 0;
 
     switch (n) {
         case 0: {
@@ -204,7 +204,7 @@ static uint64 vcpu_read_cr(struct vcpu_state_t *state, uint32 n)
     return val;
 }
 
-static void vcpu_write_cr(struct vcpu_state_t *state, uint32 n, uint64 val)
+static void vcpu_write_cr(struct vcpu_state_t *state, uint32_t n, uint64_t val)
 {
     hax_debug("vcpu_write_cr cr %x val %llx\n", n, val);
 
@@ -267,7 +267,7 @@ int set_vcpu_host(struct vcpu_t *vcpu, void *vcpu_host)
 }
 
 int set_vcpu_tunnel(struct vcpu_t *vcpu, struct hax_tunnel *tunnel,
-                    uint8 *iobuf)
+                    uint8_t *iobuf)
 {
     if (!vcpu || (vcpu->tunnel && tunnel && vcpu->tunnel != tunnel) ||
             (vcpu->io_buf && iobuf && vcpu->io_buf != iobuf))
@@ -297,8 +297,8 @@ struct hax_tunnel * get_vcpu_tunnel(struct vcpu_t *vcpu)
  */
 static int vcpu_vpid_alloc(struct vcpu_t *vcpu)
 {
-    uint32 vpid_seed_bits = sizeof(vcpu->vm->vpid_seed) * 8;
-    uint8 bit, max_bit;
+    uint32_t vpid_seed_bits = sizeof(vcpu->vm->vpid_seed) * 8;
+    uint8_t bit, max_bit;
 
     max_bit = vpid_seed_bits > 0xff ? 0xff : vpid_seed_bits;
 
@@ -309,7 +309,7 @@ static int vcpu_vpid_alloc(struct vcpu_t *vcpu)
     }
 
     for (bit = 0; bit < max_bit; bit++) {
-        if (!hax_test_and_set_bit(bit, (uint64 *)vcpu->vm->vpid_seed))
+        if (!hax_test_and_set_bit(bit, (uint64_t *)vcpu->vm->vpid_seed))
             break;
     }
 
@@ -327,7 +327,7 @@ static int vcpu_vpid_alloc(struct vcpu_t *vcpu)
      * byte.
      * Note: vpid can't be zero.
      */
-    vcpu->vpid = (uint16)(vcpu->vm->vm_id << 8) + (uint16)(bit + 1);
+    vcpu->vpid = (uint16_t)(vcpu->vm->vm_id << 8) + (uint16_t)(bit + 1);
     hax_info("vcpu_vpid_alloc: succeed! vpid: 0x%x. vcpu_id: %u, vm_id: %d.\n",
              vcpu->vpid, vcpu->vcpu_id, vcpu->vm->vm_id);
 
@@ -346,7 +346,7 @@ static int vcpu_vpid_alloc(struct vcpu_t *vcpu)
  */
 static int vcpu_vpid_free(struct vcpu_t *vcpu)
 {
-    uint8 bit = (vcpu->vpid & 0xff) - 1;
+    uint8_t bit = (vcpu->vpid & 0xff) - 1;
 
     if (0 == vcpu->vpid) {
         hax_warning("vcpu_vpid_free: vcpu %u in vm %d does not have a valid "
@@ -355,9 +355,9 @@ static int vcpu_vpid_free(struct vcpu_t *vcpu)
     }
 
     hax_info("vcpu_vpid_free: Clearing bit: 0x%x, vpid_seed: 0x%llx. "
-             "vcpu_id: %u, vm_id: %d.\n", bit, *(uint64 *)vcpu->vm->vpid_seed,
+             "vcpu_id: %u, vm_id: %d.\n", bit, *(uint64_t *)vcpu->vm->vpid_seed,
              vcpu->vcpu_id, vcpu->vm->vm_id);
-    if (0 != hax_test_and_clear_bit(bit, (uint64 *)(vcpu->vm->vpid_seed))) {
+    if (0 != hax_test_and_clear_bit(bit, (uint64_t *)(vcpu->vm->vpid_seed))) {
         hax_warning("vcpu_vpid_free: bit for vpid 0x%x of vcpu %u in vm %d was "
                     "already clear.\n", vcpu->vpid, vcpu->vcpu_id,
                     vcpu->vm->vm_id);
@@ -620,7 +620,7 @@ static int check_panic(void)
 }
 
 // Code to check the host state between vmluanch and vmexit
-static uint32 get_seg_avail(uint32 seg)
+static uint32_t get_seg_avail(uint32_t seg)
 {
     mword gdtr_base;
     struct seg_desc_t *sd;
@@ -631,7 +631,7 @@ static uint32 get_seg_avail(uint32 seg)
     return sd->_avl;
 }
 
-static void dump_segment(uint32 seg)
+static void dump_segment(uint32_t seg)
 {
     struct seg_desc_t *sd;
     mword gdtr_base;
@@ -641,7 +641,7 @@ static void dump_segment(uint32 seg)
     hax_debug("seg %x value %llx\n", seg, sd->_raw);
 }
 
-static int check_cs(uint32 seg)
+static int check_cs(uint32_t seg)
 {
     mword gdtr_base;
     mword desc_base;
@@ -671,7 +671,7 @@ static int check_cs(uint32 seg)
     return 0;
 }
 
-static int check_data_seg(uint32 seg)
+static int check_data_seg(uint32_t seg)
 {
     mword gdtr_base;
     mword desc_base;
@@ -704,7 +704,7 @@ static int check_data_seg(uint32 seg)
     return 0;
 }
 
-static int check_stack_seg(uint32 seg)
+static int check_stack_seg(uint32_t seg)
 {
     mword gdtr_base;
     mword desc_base;
@@ -735,7 +735,7 @@ static int check_stack_seg(uint32 seg)
     return 0;
 }
 
-static int check_tr_seg(uint32 seg)
+static int check_tr_seg(uint32_t seg)
 {
     mword gdtr_base;
     struct seg_desc_t *sd;
@@ -765,7 +765,7 @@ static int check_tr_seg(uint32 seg)
     return 0;
 }
 
-static int check_fgs_seg(uint32 seg, uint fs)
+static int check_fgs_seg(uint32_t seg, uint fs)
 {
     mword gdtr_base;
     mword desc_base;
@@ -816,7 +816,7 @@ static int check_fgs_seg(uint32 seg, uint fs)
 
 int vcpu_get_host_state(struct vcpu_t *vcpu, int pre)
 {
-    uint64 value;
+    uint64_t value;
     struct host_state_compare *hsc;
     hsc = pre ? &vcpu->hsc_pre : &vcpu->hsc_post;
     memset(hsc, 0, sizeof(struct host_state_compare));
@@ -912,7 +912,7 @@ int compare_host_state(struct vcpu_t *vcpu)
 }
 #endif
 
-static int is_emt64_msr(uint64 entry)
+static int is_emt64_msr(uint64_t entry)
 {
     int i = 0;
     for (i = 0; i < NR_EMT64MSR; i++) {
@@ -944,9 +944,9 @@ void save_guest_msr(struct vcpu_t *vcpu)
 
     // APM v1: save IA32_PMCx and IA32_PERFEVTSELx
     for (i = 0; i < (int)hax->apm_general_count; i++) {
-        uint32 msr = (uint32)(IA32_PMC0 + i);
+        uint32_t msr = (uint32_t)(IA32_PMC0 + i);
         gstate->apm_pmc_msrs[i] = ia32_rdmsr(msr);
-        msr = (uint32)(IA32_PERFEVTSEL0 + i);
+        msr = (uint32_t)(IA32_PERFEVTSEL0 + i);
         gstate->apm_pes_msrs[i] = ia32_rdmsr(msr);
     }
 }
@@ -972,9 +972,9 @@ void load_guest_msr(struct vcpu_t *vcpu)
 
     // APM v1: restore IA32_PMCx and IA32_PERFEVTSELx
     for (i = 0; i < (int)hax->apm_general_count; i++) {
-        uint32 msr = (uint32)(IA32_PMC0 + i);
+        uint32_t msr = (uint32_t)(IA32_PMC0 + i);
         ia32_wrmsr(msr, gstate->apm_pmc_msrs[i]);
-        msr = (uint32)(IA32_PERFEVTSEL0 + i);
+        msr = (uint32_t)(IA32_PERFEVTSEL0 + i);
         ia32_wrmsr(msr, gstate->apm_pes_msrs[i]);
     }
 }
@@ -1001,9 +1001,9 @@ static void save_host_msr(struct vcpu_t *vcpu)
 
     // APM v1: save IA32_PMCx and IA32_PERFEVTSELx
     for (i = 0; i < (int)hax->apm_general_count; i++) {
-        uint32 msr = (uint32)(IA32_PMC0 + i);
+        uint32_t msr = (uint32_t)(IA32_PMC0 + i);
         hstate->apm_pmc_msrs[i] = ia32_rdmsr(msr);
-        msr = (uint32)(IA32_PERFEVTSEL0 + i);
+        msr = (uint32_t)(IA32_PERFEVTSEL0 + i);
         hstate->apm_pes_msrs[i] = ia32_rdmsr(msr);
     }
 }
@@ -1029,9 +1029,9 @@ static void load_host_msr(struct vcpu_t *vcpu)
 
     // APM v1: restore IA32_PMCx and IA32_PERFEVTSELx
     for (i = 0; i < (int)hax->apm_general_count; i++) {
-        uint32 msr = (uint32)(IA32_PMC0 + i);
+        uint32_t msr = (uint32_t)(IA32_PMC0 + i);
         ia32_wrmsr(msr, hstate->apm_pmc_msrs[i]);
-        msr = (uint32)(IA32_PERFEVTSEL0 + i);
+        msr = (uint32_t)(IA32_PERFEVTSEL0 + i);
         ia32_wrmsr(msr, hstate->apm_pes_msrs[i]);
     }
 }
@@ -1042,8 +1042,8 @@ void vcpu_save_host_state(struct vcpu_t *vcpu)
 
     // In case we do not know the specific operations with different OSes,
     // we save all of them at the initial time
-    uint16 gs = get_kernel_gs();
-    uint16 fs = get_kernel_fs();
+    uint16_t gs = get_kernel_gs();
+    uint16_t fs = get_kernel_fs();
 
     get_kernel_gdt(&hstate->host_gdtr);
     get_kernel_idt(&hstate->host_idtr);
@@ -1166,7 +1166,7 @@ void vcpu_save_host_state(struct vcpu_t *vcpu)
 
 static void vcpu_update_exception_bitmap(struct vcpu_t *vcpu)
 {
-    uint32 exc_bitmap;
+    uint32_t exc_bitmap;
 
     exc_bitmap = (1u << VECTOR_MC);
     if (vcpu->debug_control & (HAX_DEBUG_USE_HW_BP | HAX_DEBUG_STEP)) {
@@ -1180,12 +1180,12 @@ static void vcpu_update_exception_bitmap(struct vcpu_t *vcpu)
 
 static void fill_common_vmcs(struct vcpu_t *vcpu)
 {
-    uint32 pin_ctls;
-    uint32 pcpu_ctls;
-    uint32 scpu_ctls;
-    uint32 exit_ctls = 0;
-    uint32 entry_ctls;
-    uint32 vmcs_err = 0;
+    uint32_t pin_ctls;
+    uint32_t pcpu_ctls;
+    uint32_t scpu_ctls;
+    uint32_t exit_ctls = 0;
+    uint32_t entry_ctls;
+    uint32_t vmcs_err = 0;
     uint i;
     preempt_flag flags;
     struct per_cpu_data *cpu_data;
@@ -1213,9 +1213,9 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
 
     // If vpid exists, we want it.
     if ((ia32_rdmsr(IA32_VMX_PROCBASED_CTLS) &
-        ((uint64)SECONDARY_CONTROLS << 32)) != 0) {
+        ((uint64_t)SECONDARY_CONTROLS << 32)) != 0) {
         if ((ia32_rdmsr(IA32_VMX_SECONDARY_CTLS) &
-            ((uint64)ENABLE_VPID << 32)) != 0) {
+            ((uint64_t)ENABLE_VPID << 32)) != 0) {
             if (0 != vcpu->vpid) {
                 scpu_ctls |= ENABLE_VPID;
                 vmwrite(vcpu, VMX_VPID, vcpu->vpid);
@@ -1285,7 +1285,7 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
     vmwrite(vcpu, HOST_IDTR_BASE, get_kernel_idtr_base());
 
 #define WRITE_CONTROLS(vcpu, f, v) {                                    \
-    uint32 g = v & cpu_data->vmx_info.v##_1 | cpu_data->vmx_info.v##_0; \
+    uint32_t g = v & cpu_data->vmx_info.v##_1 | cpu_data->vmx_info.v##_0; \
     vmwrite(vcpu, f, v = g);                                            \
 }
 
@@ -1431,20 +1431,20 @@ void vcpu_load_guest_state(struct vcpu_t *vcpu)
  * |size| is the number of bytes to copy, and must be one of {1, 2, 4, 8}.
  * Returns 0 on success, -1 if |size| is invalid.
  */
-static int read_low_bits(uint64 *pdst, uint64 src, uint8 size)
+static int read_low_bits(uint64_t *pdst, uint64_t src, uint8_t size)
 {
     // Assume little-endian
     switch (size) {
         case 1: {
-            *pdst = (uint8)src;
+            *pdst = (uint8_t)src;
             break;
         }
         case 2: {
-            *pdst = (uint16)src;
+            *pdst = (uint16_t)src;
             break;
         }
         case 4: {
-            *pdst = (uint32)src;
+            *pdst = (uint32_t)src;
             break;
         }
         case 8: {
@@ -1467,19 +1467,19 @@ static int read_low_bits(uint64 *pdst, uint64 src, uint8 size)
  * |size| is the number of bytes to copy, and must be one of {1, 2, 4, 8}.
  * Returns 0 on success, -1 if |size| is invalid.
  */
-static int write_low_bits(uint64 *pdst, uint64 src, uint8 size)
+static int write_low_bits(uint64_t *pdst, uint64_t src, uint8_t size)
 {
     switch (size) {
         case 1: {
-            *((uint8 *)pdst) = (uint8)src;
+            *((uint8_t *)pdst) = (uint8_t)src;
             break;
         }
         case 2: {
-            *((uint16 *)pdst) = (uint16)src;
+            *((uint16_t *)pdst) = (uint16_t)src;
             break;
         }
         case 4: {
-            *((uint32 *)pdst) = (uint32)src;
+            *((uint32_t *)pdst) = (uint32_t)src;
             break;
         }
         case 8: {
@@ -1513,15 +1513,15 @@ static void handle_io_post(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     } else {
         switch (htun->io._size) {
             case 1: {
-                state->_al = *((uint8 *)vcpu->io_buf);
+                state->_al = *((uint8_t *)vcpu->io_buf);
                 break;
             }
             case 2: {
-                state->_ax = *((uint16 *)vcpu->io_buf);
+                state->_ax = *((uint16_t *)vcpu->io_buf);
                 break;
             }
             case 4: {
-                state->_eax = *((uint32 *)vcpu->io_buf);
+                state->_eax = *((uint32_t *)vcpu->io_buf);
                 break;
             }
             default: {
@@ -1622,8 +1622,8 @@ static void advance_rip(struct vcpu_t *vcpu)
 {
     struct vcpu_state_t *state = vcpu->state;
     preempt_flag flags;
-    uint32 interruptibility = vmread(vcpu, GUEST_INTERRUPTIBILITY);
-    uint32 vmcs_err = 0;
+    uint32_t interruptibility = vmread(vcpu, GUEST_INTERRUPTIBILITY);
+    uint32_t vmcs_err = 0;
     if ((vmcs_err = load_vmcs(vcpu, &flags))) {
         hax_panic_vcpu(vcpu, "load_vmcs while advance_rip: %x", vmcs_err);
         hax_panic_log(vcpu);
@@ -1647,8 +1647,8 @@ static void advance_rip_step(struct vcpu_t *vcpu, int step)
 {
     struct vcpu_state_t *state = vcpu->state;
     preempt_flag flags;
-    uint32 interruptibility = vmread(vcpu, GUEST_INTERRUPTIBILITY);
-    uint32 vmcs_err = 0;
+    uint32_t interruptibility = vmread(vcpu, GUEST_INTERRUPTIBILITY);
+    uint32_t vmcs_err = 0;
     if ((vmcs_err = load_vmcs(vcpu, &flags))) {
         hax_panic_vcpu(vcpu, "load_vmcs while advance_rip_step: %x\n",
                        vmcs_err);
@@ -1675,7 +1675,7 @@ static void advance_rip_step(struct vcpu_t *vcpu, int step)
 void vcpu_vmread_all(struct vcpu_t *vcpu)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint32 vmcs_err = 0;
+    uint32_t vmcs_err = 0;
 
     if (vcpu->cur_state == GS_STALE) {
         preempt_flag flags;
@@ -1751,12 +1751,12 @@ void vcpu_vmwrite_all(struct vcpu_t *vcpu, int force_tlb_flush)
 // Returns 0 on success, < 0 on error.
 static int vcpu_prepare_pae_pdpt(struct vcpu_t *vcpu)
 {
-    uint64 cr3 = vcpu->state->_cr3;
+    uint64_t cr3 = vcpu->state->_cr3;
     int pdpt_size = (int)sizeof(vcpu->pae_pdptes);
 #ifdef CONFIG_HAX_EPT2
     // CR3 is the GPA of the page-directory-pointer table. According to IASDM
     // Vol. 3A 4.4.1, Table 4-7, bits 63..32 and 4..0 of this GPA are ignored.
-    uint64 gpa = cr3 & 0xffffffe0;
+    uint64_t gpa = cr3 & 0xffffffe0;
     int ret;
 
     // On Mac, the following call may somehow cause the XNU kernel to preempt
@@ -1765,7 +1765,7 @@ static int vcpu_prepare_pae_pdpt(struct vcpu_t *vcpu)
     // simply disabling IRQs). Therefore, it is not safe to call this function
     // with preemption disabled.
     ret = gpa_space_read_data(&vcpu->vm->gpa_space, gpa, pdpt_size,
-                              (uint8 *)vcpu->pae_pdptes);
+                              (uint8_t *)vcpu->pae_pdptes);
     // The PAE PDPT cannot span two page frames
     if (ret != pdpt_size) {
         hax_error("%s: Failed to read PAE PDPT: cr3=0x%llx, ret=%d\n", __func__,
@@ -1774,8 +1774,8 @@ static int vcpu_prepare_pae_pdpt(struct vcpu_t *vcpu)
     }
     return 0;
 #else // !CONFIG_HAX_EPT2
-    uint64 gpfn = (cr3 & 0xfffff000) >> PG_ORDER_4K;
-    uint8 *buf, *pdpt;
+    uint64_t gpfn = (cr3 & 0xfffff000) >> PG_ORDER_4K;
+    uint8_t *buf, *pdpt;
 #if (defined(__MACH__) || defined(_WIN64))
     buf = hax_map_gpfn(vcpu->vm, gpfn);
 #else  // !defined(__MACH__) && !defined(_WIN64), i.e. Win32
@@ -1802,36 +1802,36 @@ static void vmwrite_cr(struct vcpu_t *vcpu)
     struct vcpu_state_t *state = vcpu->state;
     struct per_cpu_data *cpu = current_cpu_data();
 
-    uint32 entry_ctls = vmx(vcpu, entry_ctls_base);
-    uint32 pcpu_ctls = vmx(vcpu, pcpu_ctls_base);
-    uint32 scpu_ctls = vmx(vcpu, scpu_ctls_base);
-    uint32 exc_bitmap = vmx(vcpu, exc_bitmap_base);
-    uint64 eptp;
+    uint32_t entry_ctls = vmx(vcpu, entry_ctls_base);
+    uint32_t pcpu_ctls = vmx(vcpu, pcpu_ctls_base);
+    uint32_t scpu_ctls = vmx(vcpu, scpu_ctls_base);
+    uint32_t exc_bitmap = vmx(vcpu, exc_bitmap_base);
+    uint64_t eptp;
 
     // If a bit is set here, the same bit of guest CR0 must be fixed to 1 (see
     // IASDM Vol. 3D A.7)
-    uint64 cr0_fixed_0 = cpu->vmx_info._cr0_fixed_0;
+    uint64_t cr0_fixed_0 = cpu->vmx_info._cr0_fixed_0;
     // If a bit is clear here, the same bit of guest CR0 must be fixed to 0 (see
     // IASDM Vol. 3D A.7)
-    uint64 cr0_fixed_1 = cpu->vmx_info._cr0_fixed_1;
+    uint64_t cr0_fixed_1 = cpu->vmx_info._cr0_fixed_1;
 
-    uint64 cr0 = (state->_cr0 & cr0_fixed_1) |
-                 (cr0_fixed_0 & (uint64)~(CR0_PE | CR0_PG));
+    uint64_t cr0 = (state->_cr0 & cr0_fixed_1) |
+                 (cr0_fixed_0 & (uint64_t)~(CR0_PE | CR0_PG));
 
-    uint64 cr0_mask;
-    uint64 cr0_shadow;
+    uint64_t cr0_mask;
+    uint64_t cr0_shadow;
 
     // If a bit is set here, the same bit of guest CR4 must be fixed to 1 (see
     // IASDM Vol. 3D A.8)
-    uint64 cr4_fixed_0 = cpu->vmx_info._cr4_fixed_0;
+    uint64_t cr4_fixed_0 = cpu->vmx_info._cr4_fixed_0;
     // If a bit is clear here, the same bit of guest CR4 must be fixed to 0 (see
     // IASDM Vol. 3D A.8)
-    uint64 cr4_fixed_1 = cpu->vmx_info._cr4_fixed_1;
+    uint64_t cr4_fixed_1 = cpu->vmx_info._cr4_fixed_1;
 
-    uint64 cr4 = ((state->_cr4 | CR4_MCE) & cr4_fixed_1) | cr4_fixed_0;
-    uint64 cr4_mask = vmx(vcpu, cr4_mask) | ~(cr4_fixed_0 ^ cr4_fixed_1) |
+    uint64_t cr4 = ((state->_cr4 | CR4_MCE) & cr4_fixed_1) | cr4_fixed_0;
+    uint64_t cr4_mask = vmx(vcpu, cr4_mask) | ~(cr4_fixed_0 ^ cr4_fixed_1) |
                       CR4_VMXE | CR4_SMXE | CR4_MCE;
-    uint64 cr4_shadow;
+    uint64_t cr4_shadow;
 
     if (hax->ug_enable_flag) {
         // In UG mode, we can allow the guest to freely modify CR0.PE without
@@ -2003,10 +2003,10 @@ static int vcpu_emulate_insn(struct vcpu_t *vcpu)
     em_status_t rc;
     em_mode_t mode;
     em_context_t *em_ctxt = &vcpu->emulate_ctxt;
-    uint8 instr[INSTR_MAX_LEN] = {0};
-    uint64 cs_base = vcpu->state->_cs.base;
-    uint64 rip = vcpu->state->_rip;
-    uint64 va;
+    uint8_t instr[INSTR_MAX_LEN] = {0};
+    uint64_t cs_base = vcpu->state->_cs.base;
+    uint64_t rip = vcpu->state->_rip;
+    uint64_t va;
 
     // Clean up the emulation context of the previous MMIO instruction, so that
     // even if things go wrong, the behavior will still be predictable.
@@ -2292,7 +2292,7 @@ static int exit_exc_nmi(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 static void handle_machine_check(struct vcpu_t *vcpu)
 {
     // Dump machine check MSRs
-    uint64 mcg_cap = ia32_rdmsr(IA32_MCG_CAP);
+    uint64_t mcg_cap = ia32_rdmsr(IA32_MCG_CAP);
     uint n, i;
 
 #define MSR_TRACE(msr) \
@@ -2312,10 +2312,10 @@ static void handle_machine_check(struct vcpu_t *vcpu)
     for (i = 0; i < n; i++) {
         MSR_TRACEi(CTL, IA32_MC0_CTL);
         MSR_TRACEi(STATUS, IA32_MC0_STATUS);
-        if (ia32_rdmsr(IA32_MC0_STATUS + i * 4) & ((uint64)1 << 58)) {
+        if (ia32_rdmsr(IA32_MC0_STATUS + i * 4) & ((uint64_t)1 << 58)) {
             MSR_TRACEi(ADDR, IA32_MC0_ADDR);
         }
-        if (ia32_rdmsr(IA32_MC0_STATUS + i * 4) & ((uint64)1 << 59)) {
+        if (ia32_rdmsr(IA32_MC0_STATUS + i * 4) & ((uint64_t)1 << 59)) {
             MSR_TRACEi(MISC, IA32_MC0_MISC);
         }
     }
@@ -2378,7 +2378,7 @@ static int exit_cpuid(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 static void handle_cpuid(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint32 a = state->_eax, c = state->_ecx;
+    uint32_t a = state->_eax, c = state->_ecx;
     cpuid_args_t args;
 
     args.eax = state->_eax;
@@ -2396,16 +2396,16 @@ static void handle_cpuid(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
 }
 
-static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
+static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t a, uint32_t c)
 {
 #define VIRT_FAMILY     0x6
 #define VIRT_MODEL      0x1F
 #define VIRT_STEPPING   0x1
     struct vcpu_state_t *state = vcpu->state;
-    uint32 hw_family;
-    uint32 hw_model;
+    uint32_t hw_family;
+    uint32_t hw_model;
 
-    static uint32 cpu_features_1 =
+    static uint32_t cpu_features_1 =
             // pat is disabled!
             FEATURE(FPU)        |
             FEATURE(VME)        |
@@ -2430,7 +2430,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
             FEATURE(PSE)        |
             FEATURE(HTT);
 
-    static uint32 cpu_features_2 =
+    static uint32_t cpu_features_2 =
             FEATURE(SSE3)       |
             FEATURE(SSSE3)      |
             FEATURE(SSE41)      |
@@ -2439,7 +2439,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
             FEATURE(MOVBE)      |
             FEATURE(POPCNT);
 
-    uint32 cpu_features_ext =
+    uint32_t cpu_features_ext =
             FEATURE(NX)         |
             FEATURE(SYSCALL)    |
             FEATURE(EM64T);
@@ -2452,7 +2452,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
         cpu_features_ext |= FEATURE(RDTSCP);
     }
 
-    uint8 physical_address_size;
+    uint8_t physical_address_size;
 
     switch (a) {
         case 0: {                       // Maximum Basic Information
@@ -2557,7 +2557,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
             // ECX and EDX represent the underlying VMM's vendor ID and should
             // be overridden.
             static const char vmm_vendor_id[13] = "HAXMHAXMHAXM";
-            const uint32 *p = (const uint32 *)vmm_vendor_id;
+            const uint32_t *p = (const uint32_t *)vmm_vendor_id;
             // Some VMMs use EAX to indicate the maximum CPUID leaf valid for
             // the range of [0x40000000, 0x4fffffff]
             state->_eax = 0x40000000;
@@ -2622,7 +2622,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32 a, uint32 c)
         case 0x80000008: {              // Virtual/Physical Address Size
             // Bit mask to identify the reserved bits in paging structure high
             // order address field
-            physical_address_size = (uint8)state->_eax & 0xff;
+            physical_address_size = (uint8_t)state->_eax & 0xff;
             pw_reserved_bits_high_mask =
                     ~((1 << (physical_address_size - 32)) - 1);
 
@@ -2661,7 +2661,7 @@ static int exit_rdtsc(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     return HAX_RESUME;
 }
 
-static void check_flush(struct vcpu_t *vcpu, uint32 bits)
+static void check_flush(struct vcpu_t *vcpu, uint32_t bits)
 {
     switch (vmx(vcpu, exit_qualification).cr.creg) {
         case 0: {
@@ -2691,12 +2691,12 @@ static void check_flush(struct vcpu_t *vcpu, uint32 bits)
 
 static int exit_cr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
-    uint64 cr_ptr;
+    uint64_t cr_ptr;
     int cr;
     struct vcpu_state_t *state = vcpu->state;
     bool is_ept_pae = false;
     preempt_flag flags;
-    uint32 vmcs_err = 0;
+    uint32_t vmcs_err = 0;
 
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
 
@@ -2705,11 +2705,11 @@ static int exit_cr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 
     switch (vmx(vcpu, exit_qualification).cr.type) {
         case 0: { // MOV CR <- GPR
-            uint64 val = state->_regs[(vmx(vcpu, exit_qualification).cr.gpr)];
+            uint64_t val = state->_regs[(vmx(vcpu, exit_qualification).cr.gpr)];
 
             hax_debug("cr_access W CR%d: %08llx -> %08llx\n", cr, cr_ptr, val);
             if (cr == 0) {
-                uint64 cr0_pae_triggers;
+                uint64_t cr0_pae_triggers;
 
                 hax_info("Guest writing to CR0[%u]: 0x%llx -> 0x%llx,"
                          " _cr4=0x%llx, _efer=0x%x\n", vcpu->vcpu_id,
@@ -2744,7 +2744,7 @@ static int exit_cr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
             }
 
             if (cr == 4) {
-                uint64 cr4_pae_triggers;
+                uint64_t cr4_pae_triggers;
 
                 hax_info("Guest writing to CR4[%u]: 0x%llx -> 0x%llx,"
                          "_cr0=0x%llx, _efer=0x%x\n", vcpu->vcpu_id,
@@ -2819,7 +2819,7 @@ static int exit_cr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
         }
         case 2: { // CLTS
             hax_info("CLTS\n");
-            state->_cr0 &= ~(uint64)CR0_TS;
+            state->_cr0 &= ~(uint64_t)CR0_TS;
             if ((vmcs_err = load_vmcs(vcpu, &flags))) {
                 hax_panic_vcpu(vcpu, "load_vmcs failed while CLTS: %x\n",
                                vmcs_err);
@@ -2868,14 +2868,14 @@ static int exit_dr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     //       We should conditionally enable "DR exiting" whenever
     //       HAX_DEBUG_USE_HW_BP is enabled, to prevent the guest from
     //       tampering with debug drN registers.
-    uint64 *dr;
+    uint64_t *dr;
     struct vcpu_state_t *state = vcpu->state;
 
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
 
     // Generally detect
     if (state->_dr7 & DR7_GD) {
-        state->_dr7 &= ~(uint64)DR7_GD;
+        state->_dr7 &= ~(uint64_t)DR7_GD;
         state->_dr6 |= DR6_BD;
         vmwrite(vcpu, GUEST_DR7, state->_dr7);
         // Priority 4 fault
@@ -2940,7 +2940,7 @@ static int handle_string_io(struct vcpu_t *vcpu, exit_qualification_t *qual,
                             struct hax_tunnel *htun)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint64 count, total_size;
+    uint64_t count, total_size;
     uint elem_size, n, copy_size;
     vaddr_t gla, start_gva;
 
@@ -3018,15 +3018,15 @@ static int handle_io(struct vcpu_t *vcpu, exit_qualification_t *qual,
     if (qual->io.direction == HAX_IO_OUT) {
         switch (qual->io.size + 1) {
             case 1: {
-                *((uint8 *)vcpu->io_buf) = state->_al;
+                *((uint8_t *)vcpu->io_buf) = state->_al;
                 break;
             }
             case 2: {
-                *((uint16 *)vcpu->io_buf) = state->_ax;
+                *((uint16_t *)vcpu->io_buf) = state->_ax;
                 break;
             }
             case 4: {
-                *((uint32 *)vcpu->io_buf) = state->_eax;
+                *((uint32_t *)vcpu->io_buf) = state->_eax;
                 break;
             }
             default: {
@@ -3069,8 +3069,8 @@ static int exit_io_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 static int exit_msr_read(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint32 msr = state->_ecx;
-    uint64 val;
+    uint32_t msr = state->_ecx;
+    uint64_t val;
 
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
 
@@ -3089,8 +3089,8 @@ static int exit_msr_read(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 static int exit_msr_write(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
     struct vcpu_state_t *state = vcpu->state;
-    uint32 msr = state->_ecx;
-    uint64 val = (uint64)(state->_edx) << 32 | state->_eax;
+    uint32_t msr = state->_ecx;
+    uint64_t val = (uint64_t)(state->_edx) << 32 | state->_eax;
 
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
 
@@ -3107,7 +3107,7 @@ static int exit_msr_write(struct vcpu_t *vcpu, struct hax_tunnel *htun)
  * Returns 0 if handled, else returns 1
  * According to the caller, return 1 will cause GP to guest
  */
-static int misc_msr_read(struct vcpu_t *vcpu, uint32 msr, uint64 *val)
+static int misc_msr_read(struct vcpu_t *vcpu, uint32_t msr, uint64_t *val)
 {
     mtrr_var_t *v;
 
@@ -3131,7 +3131,7 @@ static int misc_msr_read(struct vcpu_t *vcpu, uint32 msr, uint64 *val)
     return 1;
 }
 
-static int handle_msr_read(struct vcpu_t *vcpu, uint32 msr, uint64 *val)
+static int handle_msr_read(struct vcpu_t *vcpu, uint32_t msr, uint64_t *val)
 {
     int index, r = 0;
     struct vcpu_state_t *state = vcpu->state;
@@ -3168,7 +3168,7 @@ static int handle_msr_read(struct vcpu_t *vcpu, uint32 msr, uint64 *val)
         case IA32_SF_MASK:
         case IA32_KERNEL_GS_BASE: {
             for (index = 0; index < NR_GMSR; index++) {
-                if ((uint32)gstate->gmsr[index].entry == msr) {
+                if ((uint32_t)gstate->gmsr[index].entry == msr) {
                     *val = gstate->gmsr[index].value;
                     break;
                 }
@@ -3347,7 +3347,7 @@ static void vmwrite_efer(struct vcpu_t *vcpu)
     }
 
     if (vmx(vcpu, entry_ctls) & ENTRY_CONTROL_LOAD_EFER) {
-        uint32 guest_efer = state->_efer;
+        uint32_t guest_efer = state->_efer;
 
         if (vtlb_active(vcpu)) {
             guest_efer |= IA32_EFER_XD;
@@ -3357,7 +3357,7 @@ static void vmwrite_efer(struct vcpu_t *vcpu)
     }
 }
 
-static int misc_msr_write(struct vcpu_t *vcpu, uint32 msr, uint64 val)
+static int misc_msr_write(struct vcpu_t *vcpu, uint32_t msr, uint64_t val)
 {
     mtrr_var_t *v;
 
@@ -3384,7 +3384,7 @@ static int misc_msr_write(struct vcpu_t *vcpu, uint32 msr, uint64 val)
     return 1;
 }
 
-static int handle_msr_write(struct vcpu_t *vcpu, uint32 msr, uint64 val)
+static int handle_msr_write(struct vcpu_t *vcpu, uint32_t msr, uint64_t val)
 {
     int index, r = 0;
     struct vcpu_state_t *state = vcpu->state;
@@ -3439,7 +3439,7 @@ static int handle_msr_write(struct vcpu_t *vcpu, uint32 msr, uint64 val)
         case IA32_SF_MASK:
         case IA32_KERNEL_GS_BASE: {
             for (index = 0; index < NR_GMSR; index++) {
-                if ((uint32)gmsr_list[index] == msr) {
+                if ((uint32_t)gmsr_list[index] == msr) {
                     gstate->gmsr[index].value = val;
                     gstate->gmsr[index].entry = msr;
                     break;
@@ -3582,7 +3582,7 @@ static int exit_ept_violation(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     paddr_t gpa;
     int ret = 0;
 #ifdef CONFIG_HAX_EPT2
-    uint64 fault_gfn;
+    uint64_t fault_gfn;
 #endif
 
     htun->_exit_reason = vmx(vcpu, exit_reason).basic_reason;
@@ -3732,7 +3732,7 @@ int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *ustate)
     int cr_dirty = 0, dr_dirty = 0;
     preempt_flag flags;
     int rsp_dirty = 0;
-    uint32 vmcs_err = 0;
+    uint32_t vmcs_err = 0;
 
     if (state->_rsp != ustate->_rsp) {
         rsp_dirty = 1;
@@ -3860,12 +3860,12 @@ int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *ufl)
     return 0;
 }
 
-int vcpu_get_msr(struct vcpu_t *vcpu, uint64 entry, uint64 *val)
+int vcpu_get_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t *val)
 {
     return handle_msr_read(vcpu, entry, val);
 }
 
-int vcpu_set_msr(struct vcpu_t *vcpu, uint64 entry, uint64 val)
+int vcpu_set_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val)
 {
     return handle_msr_write(vcpu, entry, val);
 }
@@ -3901,7 +3901,7 @@ void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug)
     vcpu_update_exception_bitmap(vcpu);
 };
 
-static void vcpu_dump(struct vcpu_t *vcpu, uint32 mask, const char *caption)
+static void vcpu_dump(struct vcpu_t *vcpu, uint32_t mask, const char *caption)
 {
     vcpu_vmread_all(vcpu);
     vcpu_state_dump(vcpu);
@@ -3975,10 +3975,10 @@ static void vcpu_state_dump(struct vcpu_t *vcpu)
             vcpu->state->_gdt.limit,
             vcpu->state->_idt.base,
             vcpu->state->_idt.limit,
-            (uint32)vcpu->state->_efer);
+            (uint32_t)vcpu->state->_efer);
 }
 
-int vcpu_interrupt(struct vcpu_t *vcpu, uint8 vector)
+int vcpu_interrupt(struct vcpu_t *vcpu, uint8_t vector)
 {
     hax_set_pending_intr(vcpu, vector);
     return 1;
@@ -4055,7 +4055,7 @@ void vcpu_set_panic(struct vcpu_t *vcpu)
     vcpu->panicked = 1;
 }
 
-static int vcpu_set_apic_base(struct vcpu_t *vcpu, uint64 val)
+static int vcpu_set_apic_base(struct vcpu_t *vcpu, uint64_t val)
 {
     struct gstate *gstate = &vcpu->gstate;
 

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1874,7 +1874,7 @@ static void vmwrite_cr(struct vcpu_t *vcpu)
         // Vol. 3A 4.4.1)
         cr4_mask |= CR4_PAE;
         eptp = vm_get_eptp(vcpu->vm);
-        ASSERT(eptp != INVALID_EPTP);
+        assert(eptp != INVALID_EPTP);
         // hax_debug("Guest eip:%llx, EPT mode, eptp:%llx\n", vcpu->state->_rip,
         //           eptp);
         vmwrite(vcpu, GUEST_CR3, state->_cr3);

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1057,7 +1057,7 @@ void vcpu_save_host_state(struct vcpu_t *vcpu)
         vmwrite(vcpu, HOST_EFER, hstate->_efer);
     }
 
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     vmwrite(vcpu, HOST_CS_SELECTOR, get_kernel_cs());
 #else
     if (is_compatible()) {  // compatible
@@ -1100,7 +1100,7 @@ void vcpu_save_host_state(struct vcpu_t *vcpu)
         vmwrite(vcpu, HOST_GS_SELECTOR, 0);
     } else {
         vmwrite(vcpu, HOST_GS_SELECTOR, gs);
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
         // For ia32e mode, the MSR holds the base 3.4.4
         vmwrite(vcpu, HOST_GS_BASE, ia32_rdmsr(IA32_GS_BASE));
 #else
@@ -1121,7 +1121,7 @@ void vcpu_save_host_state(struct vcpu_t *vcpu)
         vmwrite(vcpu, HOST_FS_SELECTOR, 0);
     } else {
         vmwrite(vcpu, HOST_FS_SELECTOR, fs);
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
         // For ia32e mode, the MSR holds the base 3.4.4
         vmwrite(vcpu, HOST_FS_BASE, ia32_rdmsr(IA32_FS_BASE));
 #else
@@ -1223,7 +1223,7 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
         }
     }
 
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     exit_ctls = EXIT_CONTROL_HOST_ADDR_SPACE_SIZE | EXIT_CONTROL_LOAD_EFER |
                 EXIT_CONTROL_SAVE_DEBUG_CONTROLS;
 #endif
@@ -1252,7 +1252,7 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
     vmwrite(vcpu, HOST_CR3, get_cr3());
     vmwrite(vcpu, HOST_CR4, get_cr4());
 
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     vmwrite(vcpu, HOST_CS_SELECTOR, get_kernel_cs());
 #else
     if (is_compatible()) {
@@ -1267,7 +1267,7 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
     vmwrite(vcpu, HOST_FS_SELECTOR, get_kernel_fs());
     vmwrite(vcpu, HOST_GS_SELECTOR, get_kernel_gs());
 
-#ifdef __x86_64__
+#ifdef HAX_ARCH_X86_64
     vmwrite(vcpu, HOST_FS_BASE, ia32_rdmsr(IA32_FS_BASE));
     vmwrite(vcpu, HOST_GS_BASE, ia32_rdmsr(IA32_GS_BASE));
 #else

--- a/core/vm.c
+++ b/core/vm.c
@@ -636,7 +636,7 @@ int hax_core_set_p2m(struct vm_t *vm, uint64_t gpfn, uint64_t hpfn, uint64_t hva
 {
     int ret;
 
-    ret = set_p2m_mapping(vm, gpfn, hva & ~PAGE_MASK, hpfn << 12);
+    ret = set_p2m_mapping(vm, gpfn, hva & ~HAX_PAGE_MASK, hpfn << 12);
     if (ret < 0) {
         hax_error("Failed to set p2m mapping, gpfn:%llx, hva:%llx, hpa:%llx,"
                   "ret:%d\n", gpfn, hva, hpfn << 12, ret);

--- a/core/vm.c
+++ b/core/vm.c
@@ -36,11 +36,11 @@
 #include "include/ept.h"
 #include "include/paging.h"
 
-static uint8 vm_mid_bits = 0;
+static uint8_t vm_mid_bits = 0;
 #define VM_MID_BIT 8
 
 #if (!defined(__MACH__) && !defined(_WIN64))
-static void gpfn_to_hva_recycle_total(struct vm_t *vm, uint64 cr3_cur,
+static void gpfn_to_hva_recycle_total(struct vm_t *vm, uint64_t cr3_cur,
                                       int flag);
 #endif
 
@@ -49,7 +49,7 @@ static int get_free_vm_mid(void)
     int i;
 
     for (i = 0; i < VM_MID_BIT; i++) {
-        if (!hax_test_and_set_bit(i, (uint64 *)&vm_mid_bits))
+        if (!hax_test_and_set_bit(i, (uint64_t *)&vm_mid_bits))
             return i;
     }
 
@@ -58,7 +58,7 @@ static int get_free_vm_mid(void)
 
 static void hax_put_vm_mid(int id)
 {
-    if (hax_test_and_clear_bit(id, (uint64 *)&vm_mid_bits))
+    if (hax_test_and_clear_bit(id, (uint64_t *)&vm_mid_bits))
         hax_warning("Clear a non-set vmid %x\n", id);
 }
 
@@ -78,9 +78,9 @@ int hax_vm_set_qemuversion(struct vm_t *vm, struct hax_qemu_version *ver)
     return 0;
 }
 
-uint64 vm_get_eptp(struct vm_t *vm)
+uint64_t vm_get_eptp(struct vm_t *vm)
 {
-    uint64 eptp_value;
+    uint64_t eptp_value;
 
 #ifdef CONFIG_HAX_EPT2
     eptp_value = vm->ept_tree.eptp.value;
@@ -351,10 +351,10 @@ int set_vm_host(struct vm_t *vm, void *vm_host)
     return 0;
 }
 
-static int set_p2m_mapping(struct vm_t *vm, uint64 gpfn, uint64 hva, uint64 hpa)
+static int set_p2m_mapping(struct vm_t *vm, uint64_t gpfn, uint64_t hva, uint64_t hpa)
 {
-    uint32 which_g = gpfn_to_g(gpfn);
-    uint32 index = gpfn_in_g(gpfn);
+    uint32_t which_g = gpfn_to_g(gpfn);
+    uint32_t index = gpfn_in_g(gpfn);
     struct hax_p2m_entry *p2m_base;
 
     if (which_g >= MAX_GMEM_G)
@@ -375,10 +375,10 @@ static int set_p2m_mapping(struct vm_t *vm, uint64 gpfn, uint64 hva, uint64 hpa)
     return 0;
 }
 
-static struct hax_p2m_entry * hax_get_p2m_entry(struct vm_t *vm, uint64 gpfn)
+static struct hax_p2m_entry * hax_get_p2m_entry(struct vm_t *vm, uint64_t gpfn)
 {
-    uint32 which_g = gpfn_to_g(gpfn);
-    uint32 index = gpfn_in_g(gpfn);
+    uint32_t which_g = gpfn_to_g(gpfn);
+    uint32_t index = gpfn_in_g(gpfn);
     struct hax_p2m_entry *p2m_base;
 
     if (!vm->p2m_map[which_g])
@@ -388,7 +388,7 @@ static struct hax_p2m_entry * hax_get_p2m_entry(struct vm_t *vm, uint64 gpfn)
 }
 
 /* FIXME: This call doesn't work for 32-bit Windows. */
-static void * hax_gpfn_to_hva(struct vm_t *vm, uint64 gpfn)
+static void * hax_gpfn_to_hva(struct vm_t *vm, uint64_t gpfn)
 {
     mword hva;
     struct hax_p2m_entry *entry;
@@ -400,10 +400,10 @@ static void * hax_gpfn_to_hva(struct vm_t *vm, uint64 gpfn)
     return (void *)hva;
 }
 
-uint64 hax_gpfn_to_hpa(struct vm_t *vm, uint64 gpfn)
+uint64_t hax_gpfn_to_hpa(struct vm_t *vm, uint64_t gpfn)
 {
 #ifdef CONFIG_HAX_EPT2
-    uint64 pfn;
+    uint64_t pfn;
 
     pfn = gpa_space_get_pfn(&vm->gpa_space, gpfn, NULL);
     if (INVALID_PFN == pfn) {
@@ -411,7 +411,7 @@ uint64 hax_gpfn_to_hpa(struct vm_t *vm, uint64 gpfn)
     }
     return pfn << PG_ORDER_4K;
 #else // !CONFIG_HAX_EPT2
-    uint64 hpa;
+    uint64_t hpa;
     struct hax_p2m_entry *entry;
 
     entry = hax_get_p2m_entry(vm, gpfn);
@@ -423,7 +423,7 @@ uint64 hax_gpfn_to_hpa(struct vm_t *vm, uint64 gpfn)
 }
 
 #if (!defined(__MACH__) && !defined(_WIN64))
-static void gpfn_to_hva_recycle_total(struct vm_t *vm, uint64 cr3_cur, int flag)
+static void gpfn_to_hva_recycle_total(struct vm_t *vm, uint64_t cr3_cur, int flag)
 {
     int i = 0;
     int top = 0;
@@ -503,7 +503,7 @@ static void gpfn_to_hva_recycle_total(struct vm_t *vm, uint64 cr3_cur, int flag)
     }
 }
 
-static int gpfn_to_hva_recycle(struct vm_t *vm, uint64 cr3_cur, int flag)
+static int gpfn_to_hva_recycle(struct vm_t *vm, uint64_t cr3_cur, int flag)
 {
     int i = 0, count = 0;
     int top = 0;
@@ -538,12 +538,12 @@ static int gpfn_to_hva_recycle(struct vm_t *vm, uint64 cr3_cur, int flag)
 
 #ifndef CONFIG_HAX_EPT2
 #if (defined(__MACH__) || defined(_WIN64))
-void * hax_map_gpfn(struct vm_t *vm, uint64 gpfn)
+void * hax_map_gpfn(struct vm_t *vm, uint64_t gpfn)
 {
 #if defined(__MACH__) || defined(_WIN64)
     return hax_gpfn_to_hva(vm, gpfn);
 #else
-    uint64 hpa;
+    uint64_t hpa;
     hpa = hax_gpfn_to_hpa(vm, gpfn);
     return hax_vmap(hpa, 4096);
 #endif
@@ -557,14 +557,14 @@ void hax_unmap_gpfn(void *va)
 #endif
 }
 #else // !(defined(__MACH__) || defined(_WIN64))
-void * hax_map_gpfn(struct vm_t *vm, uint64 gpfn, bool flag, paddr_t gcr3,
-                    uint8 level)
+void * hax_map_gpfn(struct vm_t *vm, uint64_t gpfn, bool flag, paddr_t gcr3,
+                    uint8_t level)
 {
 #if defined(__MACH__) || defined(_WIN64)
     return hax_gpfn_to_hva(vm, gpfn);
 #else
     struct hax_p2m_entry *entry;
-    uint64 hpa = 0;
+    uint64_t hpa = 0;
     void *hva = NULL;
 
     entry = hax_get_p2m_entry(vm, gpfn);
@@ -577,7 +577,7 @@ retry:
         if (flag || (vm->hva_limit < HOST_VIRTUAL_ADDR_LIMIT)) {
             hva = hax_vmap(hpa, 4096);
             if (entry) {
-                entry->hva = (uint64)hva;
+                entry->hva = (uint64_t)hva;
             }
             vm->hva_limit += 4096;
             if ((vm->hva_limit > HOST_VIRTUAL_ADDR_RECYCLE) &&
@@ -586,14 +586,14 @@ retry:
                     vm->hva_index++;
                 }
                 vm->hva_list[vm->hva_index].gpfn = gpfn;
-                vm->hva_list[vm->hva_index].hva = (uint64)hva;
+                vm->hva_list[vm->hva_index].hva = (uint64_t)hva;
                 vm->hva_list[vm->hva_index].gcr3 = gcr3;
                 vm->hva_list[vm->hva_index].is_kern = flag;
                 vm->hva_list[vm->hva_index].level = level;
                 vm->hva_index++;
             } else {
                 vm->hva_list_1[vm->hva_index_1].gpfn = gpfn;
-                vm->hva_list_1[vm->hva_index_1].hva = (uint64)hva;
+                vm->hva_list_1[vm->hva_index_1].hva = (uint64_t)hva;
                 vm->hva_list_1[vm->hva_index_1].gcr3 = gcr3;
                 vm->hva_list_1[vm->hva_index_1].is_kern = flag;
                 vm->hva_list_1[vm->hva_index_1].level = level;
@@ -611,7 +611,7 @@ retry:
 #endif
 }
 
-void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64 gpfn)
+void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64_t gpfn)
 {
 #if defined(__MACH__) || defined(_WIN64)
 #else
@@ -631,8 +631,8 @@ void hax_unmap_gpfn(struct vm_t *vm, void *va, uint64 gpfn)
 #endif // (defined(__MACH__) || defined(_WIN64))
 #endif // !CONFIG_HAX_EPT2
 
-int hax_core_set_p2m(struct vm_t *vm, uint64 gpfn, uint64 hpfn, uint64 hva,
-                     uint8 flags)
+int hax_core_set_p2m(struct vm_t *vm, uint64_t gpfn, uint64_t hpfn, uint64_t hva,
+                     uint8_t flags)
 {
     int ret;
 

--- a/core/vmcs_names.c
+++ b/core/vmcs_names.c
@@ -34,12 +34,12 @@
 
 unsigned char **vmcs_names;
 
-extern uint32 vmcs_hash(uint32 enc);
+extern uint32_t vmcs_hash(uint32_t enc);
 
 /* Table produced by gperf version 3.0.4 */
-uint32 vmcs_hash(uint32 enc)
+uint32_t vmcs_hash(uint32_t enc)
 {
-    static const uint8 table[] = {
+    static const uint8_t table[] = {
           8,  48,   4, 255,   0, 255,  16, 255,  12,  66,
          37, 255,  60,  92,  85, 255, 130, 255, 138, 255,
         134, 255, 145, 255,  75, 255,  67, 255,  71, 255,

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -47,7 +47,7 @@ static void _vmx_vmwrite_64(struct vcpu_t *vcpu, const char *name,
                             component_index_t component,
                             uint64_t source_val)
 {
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     asm_vmwrite(component, (uint32_t)source_val);
     asm_vmwrite(component + 1, (uint32_t)(source_val >> 32));
 #else
@@ -59,7 +59,7 @@ static void _vmx_vmwrite_natural(struct vcpu_t *vcpu, const char *name,
                                  component_index_t component,
                                  uint64_t source_val)
 {
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     asm_vmwrite(component, (uint32_t)source_val);
 #else
     asm_vmwrite(component, source_val);
@@ -144,7 +144,7 @@ static uint64_t vmx_vmread_64(struct vcpu_t *vcpu, component_index_t component)
     uint64_t val = 0;
 
     val = asm_vmread(component);
-#ifdef _M_IX86
+#ifdef HAX_ARCH_X86_32
     val |= ((uint64_t)(asm_vmread(component + 1)) << 32);
 #endif
     return val;

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -45,11 +45,11 @@ static void _vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
 
 static void _vmx_vmwrite_64(struct vcpu_t *vcpu, const char *name,
                             component_index_t component,
-                            uint64 source_val)
+                            uint64_t source_val)
 {
 #ifdef _M_IX86
-    asm_vmwrite(component, (uint32)source_val);
-    asm_vmwrite(component + 1, (uint32)(source_val >> 32));
+    asm_vmwrite(component, (uint32_t)source_val);
+    asm_vmwrite(component + 1, (uint32_t)(source_val >> 32));
 #else
     asm_vmwrite(component, source_val);
 #endif
@@ -57,10 +57,10 @@ static void _vmx_vmwrite_64(struct vcpu_t *vcpu, const char *name,
 
 static void _vmx_vmwrite_natural(struct vcpu_t *vcpu, const char *name,
                                  component_index_t component,
-                                 uint64 source_val)
+                                 uint64_t source_val)
 {
 #ifdef _M_IX86
-    asm_vmwrite(component, (uint32)source_val);
+    asm_vmwrite(component, (uint32_t)source_val);
 #else
     asm_vmwrite(component, source_val);
 #endif
@@ -68,9 +68,9 @@ static void _vmx_vmwrite_natural(struct vcpu_t *vcpu, const char *name,
 
 static void __vmx_vmwrite_common(struct vcpu_t *vcpu, const char *name,
                                  component_index_t component,
-                                 uint64 source_val)
+                                 uint64_t source_val)
 {
-    uint8 val = (component & 0x6000) >> 13;
+    uint8_t val = (component & 0x6000) >> 13;
     switch (val) {
         case ENCODE_16:
         case ENCODE_32: {
@@ -94,10 +94,10 @@ static void __vmx_vmwrite_common(struct vcpu_t *vcpu, const char *name,
 }
 
 void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
-                 component_index_t component, uint64 source_val)
+                 component_index_t component, uint64_t source_val)
 {
     preempt_flag flags;
-    uint8 loaded = 0;
+    uint8_t loaded = 0;
 
     if (!vcpu || is_vmcs_loaded(vcpu))
         loaded = 1;
@@ -122,39 +122,39 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
 }
 
 
-static uint64 vmx_vmread(struct vcpu_t *vcpu, component_index_t component)
+static uint64_t vmx_vmread(struct vcpu_t *vcpu, component_index_t component)
 {
-    uint64 val = 0;
+    uint64_t val = 0;
 
     val = asm_vmread(component);
     return val;
 }
 
-static uint64 vmx_vmread_natural(struct vcpu_t *vcpu,
+static uint64_t vmx_vmread_natural(struct vcpu_t *vcpu,
                                  component_index_t component)
 {
-    uint64 val = 0;
+    uint64_t val = 0;
 
     val = asm_vmread(component);
     return val;
 }
 
-static uint64 vmx_vmread_64(struct vcpu_t *vcpu, component_index_t component)
+static uint64_t vmx_vmread_64(struct vcpu_t *vcpu, component_index_t component)
 {
-    uint64 val = 0;
+    uint64_t val = 0;
 
     val = asm_vmread(component);
 #ifdef _M_IX86
-    val |= ((uint64)(asm_vmread(component + 1)) << 32);
+    val |= ((uint64_t)(asm_vmread(component + 1)) << 32);
 #endif
     return val;
 }
 
-static uint64 __vmread_common(struct vcpu_t *vcpu,
+static uint64_t __vmread_common(struct vcpu_t *vcpu,
                               component_index_t component)
 {
-    uint64 value = 0;
-    uint8 val = (component >> ENCODE_SHIFT) & ENCODE_MASK;
+    uint64_t value = 0;
+    uint8_t val = (component >> ENCODE_SHIFT) & ENCODE_MASK;
 
     switch(val) {
         case ENCODE_16:
@@ -178,11 +178,11 @@ static uint64 __vmread_common(struct vcpu_t *vcpu,
     return value;
 }
 
-uint64 vmread(struct vcpu_t *vcpu, component_index_t component)
+uint64_t vmread(struct vcpu_t *vcpu, component_index_t component)
 {
     preempt_flag flags;
-    uint64 val;
-    uint8 loaded = 0;
+    uint64_t val;
+    uint8_t loaded = 0;
 
     if (!vcpu || is_vmcs_loaded(vcpu))
         loaded = 1;
@@ -208,9 +208,9 @@ uint64 vmread(struct vcpu_t *vcpu, component_index_t component)
     return val;
 }
 
-uint64 vmread_dump(struct vcpu_t *vcpu, unsigned enc, char *name)
+uint64_t vmread_dump(struct vcpu_t *vcpu, unsigned enc, char *name)
 {
-    uint64 val;
+    uint64_t val;
 
     switch ((enc >> 13) & 0x3) {
         case 0:
@@ -243,7 +243,7 @@ void vmx_read_info(info_t *vmxinfo)
 
     vmxinfo->_basic_info = ia32_rdmsr(IA32_VMX_BASIC);
 
-    if (vmxinfo->_basic_info & ((uint64)1 << 55)) {
+    if (vmxinfo->_basic_info & ((uint64_t)1 << 55)) {
         vmxinfo->pin_ctls   = ia32_rdmsr(IA32_VMX_TRUE_PINBASED_CTLS);
         vmxinfo->pcpu_ctls  = ia32_rdmsr(IA32_VMX_TRUE_PROCBASED_CTLS);
         vmxinfo->exit_ctls  = ia32_rdmsr(IA32_VMX_TRUE_EXIT_CTLS);
@@ -287,7 +287,7 @@ void vmx_read_info(info_t *vmxinfo)
         vmxinfo->_ept_cap = 0;
 }
 
-void get_interruption_info_t(interruption_info_t *info, uint8 v, uint8 t)
+void get_interruption_info_t(interruption_info_t *info, uint8_t v, uint8_t t)
 {
     info->vector = v;
     info->type = t;

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -550,7 +550,7 @@ static uint32_t vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32_t access,
     pte32_t *pte, old_pte;
     paddr_t gpt_base;
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     paddr_t g_cr3 = 0;
     bool is_kernel = false;
     int old_gpt_base;
@@ -566,7 +566,7 @@ static uint32_t vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32_t access,
     // assert((mmu->guest_mode) == PM_2LVL);
 
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     is_kernel = (va >= KERNEL_BASE) ? true : false;
 #endif
 #endif // !CONFIG_HAX_EPT2
@@ -576,7 +576,7 @@ retry:
     gpt_base = vcpu->state->_cr3 & pte32_get_cr3_mask();
 
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
        g_cr3 = gpt_base;
 #endif
 #endif // !CONFIG_HAX_EPT2
@@ -590,7 +590,7 @@ retry:
                                     gpt_base >> PG_ORDER_4K, &pte_kmap,
                                     &writable);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         pte_va = hax_map_gpfn(vcpu->vm, gpt_base >> 12, is_kernel, g_cr3, lvl);
 #else
         pte_va = hax_map_gpfn(vcpu->vm, gpt_base >> 12);
@@ -609,7 +609,7 @@ retry:
 #ifdef CONFIG_HAX_EPT2
             gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #else
             hax_unmap_gpfn(pte_va);
@@ -623,7 +623,7 @@ retry:
 #ifdef CONFIG_HAX_EPT2
             gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #else
             hax_unmap_gpfn(pte_va);
@@ -647,7 +647,7 @@ retry:
 #ifdef CONFIG_HAX_EPT2
                     gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
                     hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #else
                     hax_unmap_gpfn(pte_va);
@@ -657,7 +657,7 @@ retry:
                 }
             }
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             old_gpt_base = gpt_base;
 #endif
 #endif // !CONFIG_HAX_EPT2
@@ -665,11 +665,11 @@ retry:
 #ifdef CONFIG_HAX_EPT2
             gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             hax_unmap_gpfn(vcpu->vm, pte_va, old_gpt_base >> 12);
 #endif
 
-#if (defined(__MACH__) || defined(_WIN64))
+#ifdef HAX_ARCH_X86_64
         hax_unmap_gpfn(pte_va);
 #endif // CONFIG_HAX_EPT2
 #endif
@@ -686,7 +686,7 @@ retry:
 #ifdef CONFIG_HAX_EPT2
                 gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
                 hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #else
                 hax_unmap_gpfn(pte_va);
@@ -704,7 +704,7 @@ retry:
 #ifdef CONFIG_HAX_EPT2
                     gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
                     hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #else
                     hax_unmap_gpfn(pte_va);
@@ -765,11 +765,11 @@ retry:
 #ifdef CONFIG_HAX_EPT2
             gpa_space_unmap_page(&vcpu->vm->gpa_space, &pte_kmap);
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
             hax_unmap_gpfn(vcpu->vm, pte_va, gpt_base >> 12);
 #endif
 
-#if (defined(__MACH__) || defined(_WIN64))
+#ifdef HAX_ARCH_X86_64
             hax_unmap_gpfn(pte_va);
 #endif
 #endif // CONFIG_HAX_EPT2
@@ -940,7 +940,7 @@ uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
     int len2;
 #else // !CONFIG_HAX_EPT2
     void *hva, *hva_base;
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     bool is_kernel = false;
     paddr_t g_cr3 = 0;
 #endif
@@ -949,7 +949,7 @@ uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
     assert(flag == 0 || flag == 2);
 
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     is_kernel = addr >= KERNEL_BASE;
     g_cr3 = vcpu->state->_cr3 & pte32_get_cr3_mask();
 #endif
@@ -987,7 +987,7 @@ uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
             len = (uint64_t)len2;
         }
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         hva_base = hax_map_gpfn(vcpu->vm, gpa >> 12, is_kernel, g_cr3, 0);
 #else
         hva_base = hax_map_gpfn(vcpu->vm, gpa >> 12);
@@ -998,7 +998,7 @@ uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
         } else {
             hax_panic_vcpu(vcpu, "BUG_ON during the call:%s\n", __FUNCTION__);
         }
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         hax_unmap_gpfn(vcpu->vm, hva_base, gpa >> 12);
 #else
         hax_unmap_gpfn(hva_base);
@@ -1033,7 +1033,7 @@ uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
     int len2;
 #else // !CONFIG_HAX_EPT2
     void *hva, *hva_base;
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     bool is_kernel = false;
     paddr_t g_cr3 = 0;
 #endif
@@ -1041,7 +1041,7 @@ uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
     assert(flag == 0 || flag == 1);
 
 #ifndef CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
     is_kernel = addr >= KERNEL_BASE;
     g_cr3 = vcpu->state->_cr3 & pte32_get_cr3_mask();
 #endif
@@ -1079,7 +1079,7 @@ uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
             len = len2;
         }
 #else // !CONFIG_HAX_EPT2
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         hva_base = hax_map_gpfn(vcpu->vm, gpa >> 12, is_kernel, g_cr3, 0);
 #else
         hva_base = hax_map_gpfn(vcpu->vm, gpa >> 12);
@@ -1090,7 +1090,7 @@ uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
         } else {
             hax_panic_vcpu(vcpu, "BUG_ON during the call:%s\n", __FUNCTION__);
         }
-#if (!defined(__MACH__) && !defined(_WIN64))
+#ifdef HAX_ARCH_X86_32
         hax_unmap_gpfn(vcpu->vm, hva_base, gpa >> 12);
 #else
         hax_unmap_gpfn(hva_base);

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -93,7 +93,7 @@ static uint32 vtlb_insert_entry(struct vcpu_t *vcpu, hax_mmu_t *mmu,
     uint64 flags = 0;
 
     is_global = !!(tlb->flags & PTE32_G_BIT_MASK);
-    ASSERT(mmu->host_mode == PM_PAE && tlb->order == 12);
+    assert(mmu->host_mode == PM_PAE && tlb->order == 12);
 retry:
     pde = vtlb_get_pde(mmu, tlb->va, 0);
     shadow_pde = vtlb_get_pde(mmu, tlb->va, 1);
@@ -220,7 +220,7 @@ static struct hax_page * mmu_zalloc_one_page(hax_mmu_t *mmu, bool igo)
             hax_list_add(&page->list, &mmu->used_page_list);
         }
         page_va = hax_page_va(page);
-        ASSERT(page_va);
+        assert(page_va);
         memset(page_va, 0, PAGE_SIZE_4K);
         return page;
     }
@@ -249,7 +249,7 @@ uint vcpu_vtlb_alloc(struct vcpu_t *vcpu)
     unsigned char *pde_va, *addr;
     hax_mmu_t *mmu;
 
-    ASSERT(!vcpu->mmu);
+    assert(!vcpu->mmu);
 
     mmu = hax_vmalloc(sizeof(hax_mmu_t), 0);
 
@@ -352,7 +352,7 @@ static pte64_t * vtlb_get_pde(hax_mmu_t *mmu, vaddr_t va, bool is_shadow)
 
     pde_va = (unsigned char *)hax_page_va(pde_page) + which_g * PAGE_SIZE_4K;
 
-    ASSERT(mmu->guest_mode < PM_PAE);
+    assert(mmu->guest_mode < PM_PAE);
     pde = (pte64_t *)pde_va + idx;
     return pde;
 }
@@ -378,7 +378,7 @@ void vtlb_invalidate_addr(hax_mmu_t *mmu, vaddr_t va)
     if (mmu->clean && !igo_addr(va))
         return;
 
-    ASSERT(mmu->host_mode == PM_PAE);
+    assert(mmu->host_mode == PM_PAE);
 
     hax_debug("Flush address 0x%llx\n", va);
 
@@ -406,7 +406,7 @@ void vtlb_invalidate(hax_mmu_t *mmu)
     if (mmu->clean)
         return;
 
-    ASSERT(mmu->host_mode == PM_PAE);
+    assert(mmu->host_mode == PM_PAE);
     hax_debug("Flush whole vTLB\n");
     mmu_recycle_vtlb_pages(mmu);
 
@@ -425,7 +425,7 @@ static uint vtlb_handle_page_fault(struct vcpu_t *vcpu, pagemode_t guest_mode,
     hax_debug("vTLB::handle_pagefault %08llx, %08llx %x [Mode %u]\n", pdir, va,
               access, guest_mode);
 
-    ASSERT(guest_mode != PM_INVALID);
+    assert(guest_mode != PM_INVALID);
     if (guest_mode != mmu->guest_mode) {
         pagemode_t new_host_mode = PM_INVALID;
         switch (guest_mode) {
@@ -492,7 +492,7 @@ static uint vtlb_handle_page_fault(struct vcpu_t *vcpu, pagemode_t guest_mode,
     }
 
     tlb.order = tlb.guest_order = PG_ORDER_4K;
-    ASSERT(tlb.order == PG_ORDER_4K);
+    assert(tlb.order == PG_ORDER_4K);
 
     tlb.ha = hax_gpfn_to_hpa(vcpu->vm, gpa >> 12);
     if (!tlb.ha)
@@ -505,7 +505,7 @@ static uint vtlb_handle_page_fault(struct vcpu_t *vcpu, pagemode_t guest_mode,
      * Only PAE paging is used to emulate pure 32-bit 2-level paging.
      * Now insert the entry in the vtlb for the translation.
      */
-    ASSERT(mmu->host_mode == PM_PAE);
+    assert(mmu->host_mode == PM_PAE);
     vtlb_insert_entry(vcpu, mmu, &tlb);
     mmu->clean = 0;
 
@@ -563,7 +563,7 @@ static uint32 vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32 access,
     requested_rights = (access & (TF_WRITE | TF_USER)) |
                        (access & TF_EXEC ? EXECUTION_DISABLE_MASK : 0);
     // Seems the following one is wrong?
-    // ASSERT((mmu->guest_mode) == PM_2LVL);
+    // assert((mmu->guest_mode) == PM_2LVL);
 
 #ifndef CONFIG_HAX_EPT2
 #if (!defined(__MACH__) && !defined(_WIN64))
@@ -1169,7 +1169,7 @@ pagemode_t vcpu_get_pagemode(struct vcpu_t *vcpu)
         return PM_2LVL;
 
     // Only support pure 32-bit paging. May support PAE paging in future.
-    // ASSERT(0);
+    // assert(0);
     if (!(vcpu->state->_efer & IA32_EFER_LMA))
         return PM_PAE;
 

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -71,9 +71,9 @@ static void mmu_recycle_vtlb_pages(hax_mmu_t *mmu);
 static void vtlb_free_all_entries(hax_mmu_t *mmu);
 static pagemode_t vcpu_get_pagemode(struct vcpu_t *vcpu);
 static pte64_t * vtlb_get_pde(hax_mmu_t *mmu, vaddr_t va, bool is_shadow);
-static uint32 vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32 access,
-                            paddr_t *pa, uint *order, uint64 *flags,
-                            bool update, bool prefetch);
+static uint32_t vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32_t access,
+                              paddr_t *pa, uint *order, uint64_t *flags,
+                              bool update, bool prefetch);
 
 static void vtlb_update_pde(pte64_t *pde, pte64_t *shadow_pde,
                             struct hax_page *page)
@@ -83,14 +83,14 @@ static void vtlb_update_pde(pte64_t *pde, pte64_t *shadow_pde,
 }
 
 // Insert a vTLB entry to the system for the guest
-static uint32 vtlb_insert_entry(struct vcpu_t *vcpu, hax_mmu_t *mmu,
+static uint32_t vtlb_insert_entry(struct vcpu_t *vcpu, hax_mmu_t *mmu,
                                 vtlb_t *tlb)
 {
     pte64_t *pte_base, *pde, *shadow_pde, *pte;
     uint idx, is_user, is_write, is_exec, is_global, is_pwt, is_pcd, is_pat;
     uint base_idx, i;
     struct hax_page *page;
-    uint64 flags = 0;
+    uint64_t flags = 0;
 
     is_global = !!(tlb->flags & PTE32_G_BIT_MASK);
     assert(mmu->host_mode == PM_PAE && tlb->order == 12);
@@ -116,7 +116,7 @@ retry:
     is_write = !!((tlb->access & TF_WRITE) ||
                   ((tlb->flags & PTE32_D_BIT_MASK) &&
                   (tlb->flags & PTE32_W_BIT_MASK)));
-    is_exec = !!(tlb->flags & ((uint64)1 << 63));
+    is_exec = !!(tlb->flags & ((uint64_t)1 << 63));
     is_pwt = !!(tlb->flags & PTE32_PWT_BIT_MASK);
     is_pcd = !!(tlb->flags & PTE32_PCD_BIT_MASK);
     is_pat = !!(tlb->flags & PTE32_PAT_BIT_MASK);
@@ -141,7 +141,7 @@ retry:
         flags = vcpu->prefetch[i].flags;
         is_user = !!(flags & PTE32_USER_BIT_MASK);
         is_write = !!((flags & PTE32_D_BIT_MASK) && (flags & PTE32_W_BIT_MASK));
-        is_exec = !!(flags & ((uint64)1 << 63));
+        is_exec = !!(flags & ((uint64_t)1 << 63));
         is_pwt = !!(flags & PTE32_PWT_BIT_MASK);
         is_pcd = !!(flags & PTE32_PCD_BIT_MASK);
         is_pat = !!(flags & PTE32_PAT_BIT_MASK);
@@ -346,7 +346,7 @@ static pte64_t * vtlb_get_pde(hax_mmu_t *mmu, vaddr_t va, bool is_shadow)
     pte64_t *pde;
     void *pde_va;
     uint idx = (va >> 21) & 0x1ff;
-    uint32 which_g = va >> 30;
+    uint32_t which_g = va >> 30;
     struct hax_page *pde_page = is_shadow ? mmu->pde_shadow_page
                                           : mmu->pde_page;
 
@@ -414,7 +414,7 @@ void vtlb_invalidate(hax_mmu_t *mmu)
 }
 
 static uint vtlb_handle_page_fault(struct vcpu_t *vcpu, pagemode_t guest_mode,
-                                   paddr_t pdir, vaddr_t va, uint32 access)
+                                   paddr_t pdir, vaddr_t va, uint32_t access)
 {
     uint r;
     paddr_t gpa;
@@ -512,9 +512,9 @@ static uint vtlb_handle_page_fault(struct vcpu_t *vcpu, pagemode_t guest_mode,
     return r;
 }
 
-uint64 vtlb_get_cr3(struct vcpu_t *vcpu)
+uint64_t vtlb_get_cr3(struct vcpu_t *vcpu)
 {
-    uint64 cr3;
+    uint64_t cr3;
 
     hax_mmu_t *mmu = vcpu->mmu;
 
@@ -537,9 +537,9 @@ uint64 vtlb_get_cr3(struct vcpu_t *vcpu)
  * @returns 0 if translation is successful, otherwise 0x80000000 OR'ed with
  * the page fault error code.
  */
-static uint32 vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32 access,
-                            paddr_t *pa, uint *order, uint64 *flags,
-                            bool update, bool prefetch)
+static uint32_t vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32_t access,
+                              paddr_t *pa, uint *order, uint64_t *flags,
+                              bool update, bool prefetch)
 {
     uint lvl, idx;
     void *pte_va;
@@ -557,7 +557,7 @@ static uint32 vcpu_mmu_walk(struct vcpu_t *vcpu, vaddr_t va, uint32 access,
 #endif
 #endif // !CONFIG_HAX_EPT2
     bool pat;
-    uint64 rights, requested_rights;
+    uint64_t rights, requested_rights;
 
     access = access & (TF_WRITE | TF_USER | TF_EXEC);
     requested_rights = (access & (TF_WRITE | TF_USER)) |
@@ -678,7 +678,7 @@ retry:
             // checked at every level.
             // Allow supervisor mode writes to read-only pages unless WP=1.
             if (!(access & TF_USER) && !(vcpu->state->_cr0 & CR0_WP)) {
-                rights &= ~(uint64)TF_USER;
+                rights &= ~(uint64_t)TF_USER;
                 rights |= TF_WRITE;
             }
 
@@ -781,12 +781,12 @@ retry:
 
 bool handle_vtlb(struct vcpu_t *vcpu)
 {
-    uint32 access = vmx(vcpu, exit_exception_error_code);
+    uint32_t access = vmx(vcpu, exit_exception_error_code);
     pagemode_t mode = vcpu_get_pagemode(vcpu);
     paddr_t pdir = vcpu->state->_cr3 & (mode == PM_PAE ? ~0x1fULL : ~0xfffULL);
     vaddr_t cr2 = vmx(vcpu, exit_qualification).address;
 
-    uint32 ret = vtlb_handle_page_fault(vcpu, mode, pdir, cr2, access);
+    uint32_t ret = vtlb_handle_page_fault(vcpu, mode, pdir, cr2, access);
 
     hax_debug("handle vtlb fault @%llx\n", cr2);
     if (ret == 0) {
@@ -812,7 +812,7 @@ bool handle_vtlb(struct vcpu_t *vcpu)
 // TODO: Move these functions to another source file (e.g. mmio.c), since they
 // are not specific to vTLB mode
 static inline void * mmio_map_guest_virtual_page_fast(struct vcpu_t *vcpu,
-                                                      uint64 gva, int len)
+                                                      uint64_t gva, int len)
 {
     if (!vcpu->mmio_fetch.kva) {
         return NULL;
@@ -846,11 +846,11 @@ static inline void * mmio_map_guest_virtual_page_fast(struct vcpu_t *vcpu,
     return vcpu->mmio_fetch.kva;
 }
 
-static void * mmio_map_guest_virtual_page_slow(struct vcpu_t *vcpu, uint64 gva,
+static void * mmio_map_guest_virtual_page_slow(struct vcpu_t *vcpu, uint64_t gva,
                                                hax_kmap_user *kmap)
 {
-    uint64 gva_aligned = gva & pgmask(PG_ORDER_4K);
-    uint64 gpa;
+    uint64_t gva_aligned = gva & pgmask(PG_ORDER_4K);
+    uint64_t gpa;
     uint ret;
     void *kva;
 
@@ -874,10 +874,10 @@ static void * mmio_map_guest_virtual_page_slow(struct vcpu_t *vcpu, uint64 gva,
     return kva;
 }
 
-int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64 gva, uint8 *buf, int len)
+int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64_t gva, uint8_t *buf, int len)
 {
-    uint64 end_gva;
-    uint8 *src_buf;
+    uint64_t end_gva;
+    uint8_t *src_buf;
     uint offset;
 
     assert(vcpu != NULL);
@@ -886,7 +886,7 @@ int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64 gva, uint8 *buf, int len)
     assert(len > 0 && len <= 15);
     end_gva = gva + (uint)len - 1;
     if ((gva >> PG_ORDER_4K) != (end_gva >> PG_ORDER_4K)) {
-        uint32 ret;
+        uint32_t ret;
 
         hax_info("%s: GVA range spans two pages: gva=0x%llx, len=%d\n",
                  __func__, gva, len);
@@ -930,12 +930,12 @@ int mmio_fetch_instruction(struct vcpu_t *vcpu, uint64 gva, uint8 *buf, int len)
  * If flag is 2, the memory read is for internal use. It does not update the
  * guest page tables. It returns the number of bytes read.
  */
-uint32 vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
-                               uint32 dst_buflen, uint32 size, uint flag)
+uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
+                                 uint32_t dst_buflen, uint32_t size, uint flag)
 {
     // TBD: use guest CPL for access checks
     char *dstp = dst;
-    uint32 offset = 0;
+    uint32_t offset = 0;
 #ifdef CONFIG_HAX_EPT2
     int len2;
 #else // !CONFIG_HAX_EPT2
@@ -957,7 +957,7 @@ uint32 vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
 
     while (offset < size) {
         paddr_t gpa;
-        uint64 len = size - offset;
+        uint64_t len = size - offset;
         uint r = vcpu_translate(vcpu, addr + offset, 0, &gpa, &len, flag != 2);
         if (r != 0) {
             if (flag != 0)
@@ -977,14 +977,14 @@ uint32 vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
 //      }
 #ifdef CONFIG_HAX_EPT2
         len2 = gpa_space_read_data(&vcpu->vm->gpa_space, gpa, (int)len,
-                                   (uint8 *)(dstp + offset));
+                                   (uint8_t *)(dstp + offset));
         if (len2 <= 0) {
             hax_panic_vcpu(
                     vcpu, "read guest virtual error, gpa:0x%llx, len:0x%llx\n",
                     gpa, len);
             return false;
         } else {
-            len = (uint64)len2;
+            len = (uint64_t)len2;
         }
 #else // !CONFIG_HAX_EPT2
 #if (!defined(__MACH__) && !defined(_WIN64))
@@ -1022,13 +1022,13 @@ uint32 vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
  * A flag value of 2 is implemented, but not used. It does not update the guest
  * page tables. It returns the number of bytes written.
  */
-uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
-                                uint32 dst_buflen, const void *src, uint32 size,
-                                uint flag)
+uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
+                                  uint32_t dst_buflen, const void *src, uint32_t size,
+                                  uint flag)
 {
     // TODO: use guest CPL for access checks
     const char *srcp = src;
-    uint32 offset = 0;
+    uint32_t offset = 0;
 #ifdef CONFIG_HAX_EPT2
     int len2;
 #else // !CONFIG_HAX_EPT2
@@ -1051,7 +1051,7 @@ uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
 
     while (offset < size) {
         paddr_t gpa;
-        uint64 len = size - offset;
+        uint64_t len = size - offset;
         uint r = vcpu_translate(vcpu, addr + offset, TF_WRITE, &gpa, &len,
                                 flag != 2);
         if (r != 0) {
@@ -1068,8 +1068,8 @@ uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
             return false;
         }
 #ifdef CONFIG_HAX_EPT2
-        len2 = (uint64)gpa_space_write_data(&vcpu->vm->gpa_space, gpa, len,
-                                            (uint8 *)(srcp + offset));
+        len2 = (uint64_t)gpa_space_write_data(&vcpu->vm->gpa_space, gpa, len,
+                                            (uint8_t *)(srcp + offset));
         if (len2 <= 0) {
             hax_panic_vcpu(
                     vcpu, "write guest virtual error, gpa:0x%llx, len:0x%llx\n",
@@ -1113,7 +1113,7 @@ uint32 vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
  * number otherwise.
  */
 uint vcpu_translate(struct vcpu_t *vcpu, vaddr_t va, uint access, paddr_t *pa,
-                    uint64 *len, bool update)
+                    uint64_t *len, bool update)
 {
     pagemode_t mode = vcpu_get_pagemode(vcpu);
     uint order = 0;
@@ -1149,8 +1149,8 @@ uint vcpu_translate(struct vcpu_t *vcpu, vaddr_t va, uint access, paddr_t *pa,
          * (the minimum page size) due possible EPT remapping for the bigger
          * translation units
          */
-        uint64 size = (uint64)1 << PG_ORDER_4K;
-        uint64 extend = size - (va & (size - 1));
+        uint64_t size = (uint64_t)1 << PG_ORDER_4K;
+        uint64_t extend = size - (va & (size - 1));
 
         // Adjust validity of translation if necessary.
         if (len != NULL && (*len == 0 || *len > extend)) {

--- a/darwin/hax_driver/com_intel_hax/hax_host_mem.cpp
+++ b/darwin/hax_driver/com_intel_hax/hax_host_mem.cpp
@@ -36,7 +36,7 @@
 #include "../../../include/hax.h"
 #include "../../../core/include/paging.h"
 
-extern "C" int hax_pin_user_pages(uint64 start_uva, uint64 size,
+extern "C" int hax_pin_user_pages(uint64_t start_uva, uint64_t size,
                                   hax_memdesc_user *memdesc)
 {
     IOOptionBits options;
@@ -94,7 +94,7 @@ extern "C" int hax_unpin_user_pages(hax_memdesc_user *memdesc)
     return 0;
 }
 
-extern "C" uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset)
+extern "C" uint64_t hax_get_pfn_user(hax_memdesc_user *memdesc, uint64_t uva_offset)
 {
     addr64_t hpa;
 
@@ -117,11 +117,11 @@ extern "C" uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset)
 }
 
 extern "C" void * hax_map_user_pages(hax_memdesc_user *memdesc,
-                                     uint64 uva_offset, uint64 size,
+                                     uint64_t uva_offset, uint64_t size,
                                      hax_kmap_user *kmap)
 {
     IOByteCount base_size;
-    uint64 uva_offset_low, uva_offset_high;
+    uint64_t uva_offset_low, uva_offset_high;
     IOMemoryMap *mm;
 
     if (!memdesc) {
@@ -179,7 +179,7 @@ extern "C" int hax_unmap_user_pages(hax_kmap_user *kmap)
     return 0;
 }
 
-extern "C" int hax_alloc_page_frame(uint8 flags, hax_memdesc_phys *memdesc)
+extern "C" int hax_alloc_page_frame(uint8_t flags, hax_memdesc_phys *memdesc)
 {
     IOOptionBits options;
     IOBufferMemoryDescriptor *bmd;
@@ -235,7 +235,7 @@ extern "C" int hax_free_page_frame(hax_memdesc_phys *memdesc)
     return 0;
 }
 
-extern "C" uint64 hax_get_pfn_phys(hax_memdesc_phys *memdesc)
+extern "C" uint64_t hax_get_pfn_phys(hax_memdesc_phys *memdesc)
 {
     addr64_t hpa;
 
@@ -270,7 +270,7 @@ extern "C" void * hax_get_kva_phys(hax_memdesc_phys *memdesc)
     return memdesc->bmd->getBytesNoCopy();
 }
 
-extern "C" void * hax_map_page_frame(uint64 pfn, hax_kmap_phys *kmap)
+extern "C" void * hax_map_page_frame(uint64_t pfn, hax_kmap_phys *kmap)
 {
     IOMemoryDescriptor *md;
     IOMemoryMap *mm;

--- a/include/darwin/hax_mac.h
+++ b/include/darwin/hax_mac.h
@@ -120,12 +120,12 @@ static int hax_test_and_clear_bit(int bit, uint64_t *memory)
     return OSTestAndClear(offset, p);
 }
 
-static bool hax_cmpxchg32(uint32 old_val, uint32 new_val, volatile uint32 *addr)
+static bool hax_cmpxchg32(uint32_t old_val, uint32_t new_val, volatile uint32_t *addr)
 {
     return OSCompareAndSwap(old_val, new_val, addr);
 }
 
-static bool hax_cmpxchg64(uint64 old_val, uint64 new_val, volatile uint64 *addr)
+static bool hax_cmpxchg64(uint64_t old_val, uint64_t new_val, volatile uint64_t *addr)
 {
     return OSCompareAndSwap64(old_val, new_val, addr);
 }

--- a/include/darwin/hax_mac.h
+++ b/include/darwin/hax_mac.h
@@ -200,8 +200,6 @@ extern int default_hax_log_level;
             v->panicked = 1;          \
         }
 
-#define ASSERT(condition) assert(condition)
-
 static inline bool cpu_is_online(int cpu)
 {
     if (cpu < 0 || cpu >= max_cpus)

--- a/include/darwin/hax_types_mac.h
+++ b/include/darwin/hax_types_mac.h
@@ -130,9 +130,6 @@ typedef struct hax_kmap_phys {
 }
 #endif
 
-#define PACKED     __attribute__ ((packed))
-#define ALIGNED(x) __attribute__ ((aligned(x)))
-
 typedef ulong mword;
 typedef mword preempt_flag;
 typedef uint64_t cpumap_t;

--- a/include/darwin/hax_types_mac.h
+++ b/include/darwin/hax_types_mac.h
@@ -59,17 +59,7 @@ typedef lck_rw_t hax_rw_lock;
 
 typedef SInt32 hax_atomic_t;
 
-// Signed Types
-typedef signed char         int8;
-typedef signed short        int16;
-typedef signed int          int32;
-typedef signed long long    int64;
-
 // Unsigned Types
-typedef unsigned char       uint8;
-typedef unsigned short      uint16;
-typedef unsigned int        uint32;
-typedef unsigned long long  uint64;
 typedef unsigned long       ulong;
 
 /* Return the value before add */

--- a/include/hax.h
+++ b/include/hax.h
@@ -172,7 +172,7 @@ hax_pa_t hax_pa(void *va);
 void *hax_vmap(hax_pa_t pa, uint32_t size);
 static inline void * hax_vmap_pfn(hax_pfn_t pfn)
 {
-    return hax_vmap(pfn << PAGE_SHIFT, PAGE_SIZE);
+    return hax_vmap(pfn << HAX_PAGE_SHIFT, HAX_PAGE_SIZE);
 }
 
 /*
@@ -181,7 +181,7 @@ static inline void * hax_vmap_pfn(hax_pfn_t pfn)
 void hax_vunmap(void *va, uint32_t size);
 static inline void hax_vunmap_pfn(void *va)
 {
-    hax_vunmap((void*)((mword)va & ~PAGE_MASK), PAGE_SIZE);
+    hax_vunmap((void*)((mword)va & ~HAX_PAGE_MASK), HAX_PAGE_SIZE);
 }
 
 struct hax_page;

--- a/include/hax.h
+++ b/include/hax.h
@@ -265,11 +265,10 @@ int hax_em64t_enabled(void);
 #define HAX_LOGD        1
 #define HAX_LOG_DEFAULT 3
 
-#ifdef __MACH__
+#ifdef HAX_PLATFORM_DARWIN
 #include "darwin/hax_mac.h"
 #endif
-
-#ifdef __WINNT__
+#ifdef HAX_PLATFORM_WINDOWS
 #include "windows/hax_windows.h"
 #endif
 

--- a/include/hax_host_mem.h
+++ b/include/hax_host_mem.h
@@ -49,7 +49,7 @@ extern "C" {
 //          |start_uva| and |size| is not valid.
 // -ENOMEM: Memory allocation error.
 // -EFAULT: Host OS failing to create the memory descriptor.
-int hax_pin_user_pages(uint64 start_uva, uint64 size,
+int hax_pin_user_pages(uint64_t start_uva, uint64_t size,
                        hax_memdesc_user *memdesc);
 
 // Frees all host page frames previously pinned by hax_pin_user_pages().
@@ -67,7 +67,7 @@ int hax_unpin_user_pages(hax_memdesc_user *memdesc);
 // |uva_offset|: The offset, in bytes, of the virtual page (or any byte within
 //               it) in the UVA range described by |memdesc|.
 // Returns INVALID_PFN on error.
-uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset);
+uint64_t hax_get_pfn_user(hax_memdesc_user *memdesc, uint64_t uva_offset);
 
 // Maps the given subrange of the UVA range described by the given
 // |hax_memdesc_user| into KVA space, stores the mapping in the given buffer,
@@ -80,8 +80,8 @@ uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset);
 // |size|: The size of the UVA subrange, in bytes. Should be page-aligned.
 // |kmap|: A buffer to store a host-specific KVA mapping descriptor.
 // Returns NULL on error.
-void * hax_map_user_pages(hax_memdesc_user *memdesc, uint64 uva_offset,
-                          uint64 size, hax_kmap_user *kmap);
+void * hax_map_user_pages(hax_memdesc_user *memdesc, uint64_t uva_offset,
+                          uint64_t size, hax_kmap_user *kmap);
 
 // Destroys the given KVA mapping previously created by hax_map_user_pages().
 // Returns 0 on success, or one of the following error codes:
@@ -97,7 +97,7 @@ int hax_unmap_user_pages(hax_kmap_user *kmap);
 // Returns 0 on success, or one of the following error codes:
 // -EINVAL: Invalid input, e.g. |memdesc| is NULL.
 // -ENOMEM: Memory allocation error.
-int hax_alloc_page_frame(uint8 flags, hax_memdesc_phys *memdesc);
+int hax_alloc_page_frame(uint8_t flags, hax_memdesc_phys *memdesc);
 
 // Indicates that the allocated page frame should be initialized with zeroes
 #define HAX_PAGE_ALLOC_ZEROED   0x01
@@ -114,7 +114,7 @@ int hax_free_page_frame(hax_memdesc_phys *memdesc);
 // Returns the PFN of the host page frame described by the given
 // |hax_memdesc_phys|, which was previously populated by hax_alloc_page_frame().
 // Returns INVALID_PFN on error.
-uint64 hax_get_pfn_phys(hax_memdesc_phys *memdesc);
+uint64_t hax_get_pfn_phys(hax_memdesc_phys *memdesc);
 
 // Returns the KVA of the host page frame described by the given
 // |hax_memdesc_phys|, which was previously populated by hax_alloc_page_frame().
@@ -128,7 +128,7 @@ void * hax_get_kva_phys(hax_memdesc_phys *memdesc);
 // |pfn|: pfn: The PFN to map.
 // |kmap|: A buffer to store a host-specific KVA mapping descriptor.
 // Returns NULL on error.
-void * hax_map_page_frame(uint64 pfn, hax_kmap_phys *kmap);
+void * hax_map_page_frame(uint64_t pfn, hax_kmap_phys *kmap);
 
 // Destroys the given KVA mapping previously created by hax_map_page_frame().
 // Returns 0 on success (including the case where |kmap| is neither NULL nor a

--- a/include/hax_interface.h
+++ b/include/hax_interface.h
@@ -56,33 +56,33 @@ struct vmx_msr {
 
 /* fx_layout has 3 formats table 3-56, 512bytes */
 struct fx_layout {
-    uint16  fcw;
-    uint16  fsw;
-    uint8   ftw;
-    uint8   res1;
-    uint16  fop;
+    uint16_t  fcw;
+    uint16_t  fsw;
+    uint8_t   ftw;
+    uint8_t   res1;
+    uint16_t  fop;
     union {
         struct {
-            uint32  fip;
-            uint16  fcs;
-            uint16  res2;
+            uint32_t  fip;
+            uint16_t  fcs;
+            uint16_t  res2;
         };
-        uint64  fpu_ip;
+        uint64_t  fpu_ip;
     };
     union {
         struct {
-            uint32  fdp;
-            uint16  fds;
-            uint16  res3;
+            uint32_t  fdp;
+            uint16_t  fds;
+            uint16_t  res3;
         };
-        uint64  fpu_dp;
+        uint64_t  fpu_dp;
     };
-    uint32  mxcsr;
-    uint32  mxcsr_mask;
-    uint8   st_mm[8][16];
-    uint8   mmx_1[8][16];
-    uint8   mmx_2[8][16];
-    uint8   pad[96];
+    uint32_t  mxcsr;
+    uint32_t  mxcsr_mask;
+    uint8_t   st_mm[8][16];
+    uint8_t   mmx_1[8][16];
+    uint8_t   mmx_2[8][16];
+    uint8_t   pad[96];
 } ALIGNED(16);
 
 /*

--- a/include/hax_interface.h
+++ b/include/hax_interface.h
@@ -39,11 +39,10 @@
 
 #include "hax_types.h"
 
-#ifdef __MACH__
+#ifdef HAX_PLATFORM_DARWIN
 #include "darwin/hax_interface_mac.h"
 #endif
-
-#ifdef __WINNT__
+#ifdef HAX_PLATFORM_WINDOWS
 #include "windows/hax_interface_windows.h"
 #endif
 

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -197,7 +197,7 @@ typedef enum component_index_t component_index_t;
 #include "windows/hax_types_windows.h"
 #endif
 
-/* Common typedef for all platform */
+/* Common typedef for all platforms */
 typedef uint64_t hax_pa_t;
 typedef uint64_t hax_pfn_t;
 typedef uint64_t paddr_t;

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -36,37 +36,42 @@
 #if defined(__i386__) || defined(_M_IX86)
 #define HAX_ARCH_X86_32
 #define ASMCALL __cdecl
-#endif
 // x86 (64-bit)
-#if defined(__x86_64__) || defined(_M_X64)
+#elif defined(__x86_64__) || defined(_M_X64)
 #define HAX_ARCH_X86_64
 #define ASMCALL
+#else
+#error "Unsupported architecture"
 #endif
 
 /* Detect compiler */
 // Clang
-#ifdef __clang__
+#if defined(__clang__)
 #define HAX_COMPILER_CLANG
 #define PACKED     __attribute__ ((packed))
 #define ALIGNED(x) __attribute__ ((aligned(x)))
-#endif
 // MSVC
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
 #define HAX_COMPILER_MSVC
-#define PACKED
+// FIXME: MSVC doesn't have a simple equivalent for PACKED.
+//        Instead, The corresponding #pragma directives are added manually.
+#define PACKED     
 #define ALIGNED(x) __declspec(align(x))
+#else
+#error "Unsupported compiler"
 #endif
 
 /* Detect platform */
 // MacOS
-#ifdef __MACH__
+#if defined(__MACH__)
 #define HAX_PLATFORM_DARWIN
 #include "darwin/hax_types_mac.h"
-#endif
 // Windows
-#ifdef __WINNT__
+#elif defined(__WINNT__)
 #define HAX_PLATFORM_WINDOWS
 #include "windows/hax_types_windows.h"
+#else
+#error "Unsupported platform"
 #endif
 
 #define HAX_PAGE_SIZE  4096

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -31,182 +31,52 @@
 #ifndef HAX_TYPES_H_
 #define HAX_TYPES_H_
 
-enum component_index_t {
-    VMX_PIN_CONTROLS                            = 0x00004000,
-    VMX_PRIMARY_PROCESSOR_CONTROLS              = 0x00004002,
-    VMX_SECONDARY_PROCESSOR_CONTROLS            = 0x0000401e,
-    VMX_EXCEPTION_BITMAP                        = 0x00004004,
-    VMX_PAGE_FAULT_ERROR_CODE_MASK              = 0x00004006,
-    VMX_PAGE_FAULT_ERROR_CODE_MATCH             = 0x00004008,
-    VMX_EXIT_CONTROLS                           = 0x0000400c,
-    VMX_EXIT_MSR_STORE_COUNT                    = 0x0000400e,
-    VMX_EXIT_MSR_LOAD_COUNT                     = 0x00004010,
-    VMX_ENTRY_CONTROLS                          = 0x00004012,
-    VMX_ENTRY_MSR_LOAD_COUNT                    = 0x00004014,
-    VMX_ENTRY_INTERRUPT_INFO                    = 0x00004016,
-    VMX_ENTRY_EXCEPTION_ERROR_CODE              = 0x00004018,
-    VMX_ENTRY_INSTRUCTION_LENGTH                = 0x0000401a,
-    VMX_TPR_THRESHOLD                           = 0x0000401c,
+/* Detect architecture */
+// x86 (32-bit)
+#if defined(__i386__) || defined(_M_IX86)
+#define HAX_ARCH_X86_32
+#define ASMCALL __cdecl
+#endif
+// x86 (64-bit)
+#if defined(__x86_64__) || defined(_M_X64)
+#define HAX_ARCH_X86_64
+#define ASMCALL
+#endif
 
-    VMX_CR0_MASK                                = 0x00006000,
-    VMX_CR4_MASK                                = 0x00006002,
-    VMX_CR0_READ_SHADOW                         = 0x00006004,
-    VMX_CR4_READ_SHADOW                         = 0x00006006,
-    VMX_CR3_TARGET_COUNT                        = 0x0000400a,
-    VMX_CR3_TARGET_VAL_BASE                     = 0x00006008, // x6008-x6206
+/* Detect compiler */
+// Clang
+#ifdef __clang__
+#define HAX_COMPILER_CLANG
+#define PACKED     __attribute__ ((packed))
+#define ALIGNED(x) __attribute__ ((aligned(x)))
+#endif
+// MSVC
+#ifdef _MSC_VER
+#define HAX_COMPILER_MSVC
+#define PACKED
+#define ALIGNED(x) __declspec(align(x))
+#endif
 
-    VMX_VPID                                    = 0x00000000,
-    VMX_IO_BITMAP_A                             = 0x00002000,
-    VMX_IO_BITMAP_B                             = 0x00002002,
-    VMX_MSR_BITMAP                              = 0x00002004,
-    VMX_EXIT_MSR_STORE_ADDRESS                  = 0x00002006,
-    VMX_EXIT_MSR_LOAD_ADDRESS                   = 0x00002008,
-    VMX_ENTRY_MSR_LOAD_ADDRESS                  = 0x0000200a,
-    VMX_TSC_OFFSET                              = 0x00002010,
-    VMX_VAPIC_PAGE                              = 0x00002012,
-    VMX_APIC_ACCESS_PAGE                        = 0x00002014,
-    VMX_EPTP                                    = 0x0000201a,
-    VMX_PREEMPTION_TIMER                        = 0x0000482e,
-
-    VMX_INSTRUCTION_ERROR_CODE                  = 0x00004400,
-
-    VM_EXIT_INFO_REASON                         = 0x00004402,
-    VM_EXIT_INFO_INTERRUPT_INFO                 = 0x00004404,
-    VM_EXIT_INFO_EXCEPTION_ERROR_CODE           = 0x00004406,
-    VM_EXIT_INFO_IDT_VECTORING                  = 0x00004408,
-    VM_EXIT_INFO_IDT_VECTORING_ERROR_CODE       = 0x0000440a,
-    VM_EXIT_INFO_INSTRUCTION_LENGTH             = 0x0000440c,
-    VM_EXIT_INFO_INSTRUCTION_INFO               = 0x0000440e,
-    VM_EXIT_INFO_QUALIFICATION                  = 0x00006400,
-    VM_EXIT_INFO_IO_ECX                         = 0x00006402,
-    VM_EXIT_INFO_IO_ESI                         = 0x00006404,
-    VM_EXIT_INFO_IO_EDI                         = 0x00006406,
-    VM_EXIT_INFO_IO_EIP                         = 0x00006408,
-    VM_EXIT_INFO_GUEST_LINEAR_ADDRESS           = 0x0000640a,
-    VM_EXIT_INFO_GUEST_PHYSICAL_ADDRESS         = 0x00002400,
-
-    HOST_RIP                                    = 0x00006c16,
-    HOST_RSP                                    = 0x00006c14,
-    HOST_CR0                                    = 0x00006c00,
-    HOST_CR3                                    = 0x00006c02,
-    HOST_CR4                                    = 0x00006c04,
-
-    HOST_CS_SELECTOR                            = 0x00000c02,
-    HOST_DS_SELECTOR                            = 0x00000c06,
-    HOST_ES_SELECTOR                            = 0x00000c00,
-    HOST_FS_SELECTOR                            = 0x00000c08,
-    HOST_GS_SELECTOR                            = 0x00000c0a,
-    HOST_SS_SELECTOR                            = 0x00000c04,
-    HOST_TR_SELECTOR                            = 0x00000c0c,
-    HOST_FS_BASE                                = 0x00006c06,
-    HOST_GS_BASE                                = 0x00006c08,
-    HOST_TR_BASE                                = 0x00006c0a,
-    HOST_GDTR_BASE                              = 0x00006c0c,
-    HOST_IDTR_BASE                              = 0x00006c0e,
-
-    HOST_SYSENTER_CS                            = 0x00004c00,
-    HOST_SYSENTER_ESP                           = 0x00006c10,
-    HOST_SYSENTER_EIP                           = 0x00006c12,
-
-    HOST_PAT                                    = 0x00002c00,
-    HOST_EFER                                   = 0x00002c02,
-    HOST_PERF_GLOBAL_CTRL                       = 0x00002c04,
-
-
-    GUEST_RIP                                   = 0x0000681e,
-    GUEST_RFLAGS                                = 0x00006820,
-    GUEST_RSP                                   = 0x0000681c,
-    GUEST_CR0                                   = 0x00006800,
-    GUEST_CR3                                   = 0x00006802,
-    GUEST_CR4                                   = 0x00006804,
-
-    GUEST_ES_SELECTOR                           = 0x00000800,
-    GUEST_CS_SELECTOR                           = 0x00000802,
-    GUEST_SS_SELECTOR                           = 0x00000804,
-    GUEST_DS_SELECTOR                           = 0x00000806,
-    GUEST_FS_SELECTOR                           = 0x00000808,
-    GUEST_GS_SELECTOR                           = 0x0000080a,
-    GUEST_LDTR_SELECTOR                         = 0x0000080c,
-    GUEST_TR_SELECTOR                           = 0x0000080e,
-
-    GUEST_ES_AR                                 = 0x00004814,
-    GUEST_CS_AR                                 = 0x00004816,
-    GUEST_SS_AR                                 = 0x00004818,
-    GUEST_DS_AR                                 = 0x0000481a,
-    GUEST_FS_AR                                 = 0x0000481c,
-    GUEST_GS_AR                                 = 0x0000481e,
-    GUEST_LDTR_AR                               = 0x00004820,
-    GUEST_TR_AR                                 = 0x00004822,
-
-    GUEST_ES_BASE                               = 0x00006806,
-    GUEST_CS_BASE                               = 0x00006808,
-    GUEST_SS_BASE                               = 0x0000680a,
-    GUEST_DS_BASE                               = 0x0000680c,
-    GUEST_FS_BASE                               = 0x0000680e,
-    GUEST_GS_BASE                               = 0x00006810,
-    GUEST_LDTR_BASE                             = 0x00006812,
-    GUEST_TR_BASE                               = 0x00006814,
-    GUEST_GDTR_BASE                             = 0x00006816,
-    GUEST_IDTR_BASE                             = 0x00006818,
-
-    GUEST_ES_LIMIT                              = 0x00004800,
-    GUEST_CS_LIMIT                              = 0x00004802,
-    GUEST_SS_LIMIT                              = 0x00004804,
-    GUEST_DS_LIMIT                              = 0x00004806,
-    GUEST_FS_LIMIT                              = 0x00004808,
-    GUEST_GS_LIMIT                              = 0x0000480a,
-    GUEST_LDTR_LIMIT                            = 0x0000480c,
-    GUEST_TR_LIMIT                              = 0x0000480e,
-    GUEST_GDTR_LIMIT                            = 0x00004810,
-    GUEST_IDTR_LIMIT                            = 0x00004812,
-
-    GUEST_VMCS_LINK_PTR                         = 0x00002800,
-    GUEST_DEBUGCTL                              = 0x00002802,
-    GUEST_PAT                                   = 0x00002804,
-    GUEST_EFER                                  = 0x00002806,
-    GUEST_PERF_GLOBAL_CTRL                      = 0x00002808,
-    GUEST_PDPTE0                                = 0x0000280a,
-    GUEST_PDPTE1                                = 0x0000280c,
-    GUEST_PDPTE2                                = 0x0000280e,
-    GUEST_PDPTE3                                = 0x00002810,
-
-    GUEST_DR7                                   = 0x0000681a,
-    GUEST_PENDING_DBE                           = 0x00006822,
-    GUEST_SYSENTER_CS                           = 0x0000482a,
-    GUEST_SYSENTER_ESP                          = 0x00006824,
-    GUEST_SYSENTER_EIP                          = 0x00006826,
-    GUEST_SMBASE                                = 0x00004828,
-    GUEST_INTERRUPTIBILITY                      = 0x00004824,
-    GUEST_ACTIVITY_STATE                        = 0x00004826,
-
-    /* Invalid encoding */
-    VMCS_NO_COMPONENT                           = 0x0000ffff
-};
-
-typedef enum component_index_t component_index_t;
+/* Detect platform */
+// MacOS
+#ifdef __MACH__
+#define HAX_PLATFORM_DARWIN
+#include "darwin/hax_types_mac.h"
+#endif
+// Windows
+#ifdef __WINNT__
+#define HAX_PLATFORM_WINDOWS
+#include "windows/hax_types_windows.h"
+#endif
 
 #define HAX_PAGE_SIZE  4096
 #define HAX_PAGE_SHIFT 12
 #define HAX_PAGE_MASK  0xfff
-
-#ifdef __MACH__
-#include "darwin/hax_types_mac.h"
-#endif
-
-#ifdef __WINNT__
-#include "windows/hax_types_windows.h"
-#endif
 
 /* Common typedef for all platforms */
 typedef uint64_t hax_pa_t;
 typedef uint64_t hax_pfn_t;
 typedef uint64_t paddr_t;
 typedef uint64_t vaddr_t;
-
-#ifdef _M_IX86
-#define ASMCALL __cdecl
-#else  // !_M_IX86
-#define ASMCALL
-#endif  // _M_IX86
 
 #endif  // HAX_TYPES_H_

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -194,12 +194,12 @@ typedef enum component_index_t component_index_t;
 #endif
 
 /* Common typedef for all platform */
-typedef uint64 hax_pa_t;
-typedef uint64 hax_pfn_t;
-typedef uint64 paddr_t;
-typedef uint64 vaddr_t;
+typedef uint64_t hax_pa_t;
+typedef uint64_t hax_pfn_t;
+typedef uint64_t paddr_t;
+typedef uint64_t vaddr_t;
 
-extern int32 hax_page_size;
+extern int32_t hax_page_size;
 
 #ifdef _M_IX86
 #define ASMCALL __cdecl

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -185,6 +185,10 @@ enum component_index_t {
 
 typedef enum component_index_t component_index_t;
 
+#define HAX_PAGE_SIZE  4096
+#define HAX_PAGE_SHIFT 12
+#define HAX_PAGE_MASK  0xfff
+
 #ifdef __MACH__
 #include "darwin/hax_types_mac.h"
 #endif
@@ -198,8 +202,6 @@ typedef uint64_t hax_pa_t;
 typedef uint64_t hax_pfn_t;
 typedef uint64_t paddr_t;
 typedef uint64_t vaddr_t;
-
-extern int32_t hax_page_size;
 
 #ifdef _M_IX86
 #define ASMCALL __cdecl

--- a/include/vcpu_state.h
+++ b/include/vcpu_state.h
@@ -32,13 +32,13 @@
 #define HAX_VCPU_STATE_H_
 
 union interruptibility_state_t {
-    uint32 raw;
+    uint32_t raw;
     struct {
-        uint32 sti_blocking   : 1;
-        uint32 movss_blocking : 1;
-        uint32 smi_blocking   : 1;
-        uint32 nmi_blocking   : 1;
-        uint32 reserved       : 28;
+        uint32_t sti_blocking   : 1;
+        uint32_t movss_blocking : 1;
+        uint32_t smi_blocking   : 1;
+        uint32_t nmi_blocking   : 1;
+        uint32_t reserved       : 28;
     };
     uint64_t pad;
 } PACKED;
@@ -47,111 +47,111 @@ typedef union interruptibility_state_t interruptibility_state_t;
 
 // Segment descriptor
 struct segment_desc_t {
-    uint16 selector;
-    uint16 _dummy;
-    uint32 limit;
-    uint64 base;
+    uint16_t selector;
+    uint16_t _dummy;
+    uint32_t limit;
+    uint64_t base;
     union {
         struct {
-            uint32 type             : 4;
-            uint32 desc             : 1;
-            uint32 dpl              : 2;
-            uint32 present          : 1;
-            uint32                  : 4;
-            uint32 available        : 1;
-            uint32 long_mode        : 1;
-            uint32 operand_size     : 1;
-            uint32 granularity      : 1;
-            uint32 null             : 1;
-            uint32                  : 15;
+            uint32_t type             : 4;
+            uint32_t desc             : 1;
+            uint32_t dpl              : 2;
+            uint32_t present          : 1;
+            uint32_t                  : 4;
+            uint32_t available        : 1;
+            uint32_t long_mode        : 1;
+            uint32_t operand_size     : 1;
+            uint32_t granularity      : 1;
+            uint32_t null             : 1;
+            uint32_t                  : 15;
         };
-        uint32 ar;
+        uint32_t ar;
     };
-    uint32 ipad;
+    uint32_t ipad;
 } PACKED;
 
 typedef struct segment_desc_t segment_desc_t;
 
 struct vcpu_state_t {
     union {
-        uint64 _regs[16];
+        uint64_t _regs[16];
         struct {
             union {
                 struct {
-                    uint8 _al,
-                          _ah;
+                    uint8_t _al,
+                            _ah;
                 };
-                uint16    _ax;
-                uint32    _eax;
-                uint64    _rax;
+                uint16_t    _ax;
+                uint32_t    _eax;
+                uint64_t    _rax;
             };
             union {
                 struct {
-                    uint8 _cl,
-                          _ch;
+                    uint8_t _cl,
+                            _ch;
                 };
-                uint16    _cx;
-                uint32    _ecx;
-                uint64    _rcx;
+                uint16_t    _cx;
+                uint32_t    _ecx;
+                uint64_t    _rcx;
             };
             union {
                 struct {
-                    uint8 _dl,
-                          _dh;
+                    uint8_t _dl,
+                            _dh;
                 };
-                uint16    _dx;
-                uint32    _edx;
-                uint64    _rdx;
+                uint16_t    _dx;
+                uint32_t    _edx;
+                uint64_t    _rdx;
             };
             union {
                 struct {
-                    uint8 _bl,
-                          _bh;
+                    uint8_t _bl,
+                            _bh;
                 };
-                uint16    _bx;
-                uint32    _ebx;
-                uint64    _rbx;
+                uint16_t    _bx;
+                uint32_t    _ebx;
+                uint64_t    _rbx;
             };
             union {
-                uint16    _sp;
-                uint32    _esp;
-                uint64    _rsp;
+                uint16_t    _sp;
+                uint32_t    _esp;
+                uint64_t    _rsp;
             };
             union {
-                uint16    _bp;
-                uint32    _ebp;
-                uint64    _rbp;
+                uint16_t    _bp;
+                uint32_t    _ebp;
+                uint64_t    _rbp;
             };
             union {
-                uint16    _si;
-                uint32    _esi;
-                uint64    _rsi;
+                uint16_t    _si;
+                uint32_t    _esi;
+                uint64_t    _rsi;
             };
             union {
-                uint16    _di;
-                uint32    _edi;
-                uint64    _rdi;
+                uint16_t    _di;
+                uint32_t    _edi;
+                uint64_t    _rdi;
             };
 
-            uint64 _r8;
-            uint64 _r9;
-            uint64 _r10;
-            uint64 _r11;
-            uint64 _r12;
-            uint64 _r13;
-            uint64 _r14;
-            uint64 _r15;
+            uint64_t _r8;
+            uint64_t _r9;
+            uint64_t _r10;
+            uint64_t _r11;
+            uint64_t _r12;
+            uint64_t _r13;
+            uint64_t _r14;
+            uint64_t _r15;
         };
     };
 
     union {
-        uint32 _eip;
-        uint64 _rip;
+        uint32_t _eip;
+        uint64_t _rip;
     };
 
     union {
-        uint32 _eflags;
-        uint64 _rflags;
+        uint32_t _eflags;
+        uint64_t _rflags;
     };
 
     segment_desc_t _cs;
@@ -166,27 +166,27 @@ struct vcpu_state_t {
     segment_desc_t _gdt;
     segment_desc_t _idt;
 
-    uint64 _cr0;
-    uint64 _cr2;
-    uint64 _cr3;
-    uint64 _cr4;
+    uint64_t _cr0;
+    uint64_t _cr2;
+    uint64_t _cr3;
+    uint64_t _cr4;
 
-    uint64 _dr0;
-    uint64 _dr1;
-    uint64 _dr2;
-    uint64 _dr3;
-    uint64 _dr6;
-    uint64 _dr7;
-    uint64 _pde;
+    uint64_t _dr0;
+    uint64_t _dr1;
+    uint64_t _dr2;
+    uint64_t _dr3;
+    uint64_t _dr6;
+    uint64_t _dr7;
+    uint64_t _pde;
 
-    uint32 _efer;
+    uint32_t _efer;
 
-    uint32 _sysenter_cs;
-    uint64 _sysenter_eip;
-    uint64 _sysenter_esp;
+    uint32_t _sysenter_cs;
+    uint64_t _sysenter_eip;
+    uint64_t _sysenter_esp;
 
-    uint32 _activity_state;
-    uint32 pad;
+    uint32_t _activity_state;
+    uint32_t pad;
     interruptibility_state_t _interruptibility_state;
 } PACKED;
 

--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -103,7 +103,6 @@ typedef struct {
 
 typedef FAST_MUTEX *hax_mutex;
 
-#define PAGE_MASK (((mword)0x1 << 12) - 1)
 /* In DDK, the InterlockedXXX using ULONG, which is in fact 32bit */
 typedef LONG hax_atomic_t;
 

--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -124,9 +124,6 @@ static hax_atomic_t hax_atomic_dec(volatile hax_atomic_t *atom)
     return InterlockedDecrement(atom) + 1;
 }
 
-#define ALIGNED(x) __declspec(align(x))
-#define PACKED
-
 #if defined(_X86_)
 typedef uint32_t mword;
 #endif

--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -54,23 +54,18 @@ inline cpumap_t cpu2cpumap(int cpu)
 typedef KIRQL preempt_flag;
 
 // Signed Types
-typedef signed char         int8;
-typedef signed short        int16;
-typedef signed int          int32;
-typedef signed long long    int64;
+typedef signed char         int8_t;
+typedef signed short        int16_t;
+typedef signed int          int32_t;
+typedef signed long long    int64_t;
 
 // Unsigned Types
-typedef unsigned char       uint8;
-typedef unsigned short      uint16;
-typedef unsigned int        uint32;
-typedef unsigned int        uint;
-typedef unsigned long long  uint64;
-typedef unsigned long       ulong;
-
 typedef unsigned char       uint8_t;
 typedef unsigned short      uint16_t;
 typedef unsigned int        uint32_t;
 typedef unsigned long long  uint64_t;
+typedef unsigned int        uint;
+typedef unsigned long       ulong;
 typedef unsigned long       ulong_t;
 
 #include "../hax_list.h"

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -34,12 +34,6 @@
 //#include <ntddk.h>
 #include <ntifs.h>
 
-#ifdef _WIN64
-#define __x86_64__ 1
-#else
-#define __i386__ 1
-#endif
-
 #ifndef HAX_UNIFIED_BINARY
 
 /*

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -170,7 +170,7 @@ static bool hax_test_bit(int bit, uint64_t *memory)
 }
 
 /* Why it's a bool? Strange */
-static bool hax_cmpxchg32(uint32 old_val, uint32 new_val, volatile uint32 *addr)
+static bool hax_cmpxchg32(uint32_t old_val, uint32_t new_val, volatile uint32_t *addr)
 {
     long ret;
 
@@ -182,7 +182,7 @@ static bool hax_cmpxchg32(uint32 old_val, uint32 new_val, volatile uint32 *addr)
         return FALSE;
 }
 
-static bool hax_cmpxchg64(uint64 old_val, uint64 new_val, volatile uint64 *addr)
+static bool hax_cmpxchg64(uint64_t old_val, uint64_t new_val, volatile uint64_t *addr)
 {
     LONGLONG ret;
 

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -56,10 +56,6 @@
 #define HAX_RAM_ENTRY_SIZE 0x2000000
 #endif
 
-#define page_size 4096
-#define page_shift 12
-#define page_mask 0xfff
-
 static inline hax_spinlock *hax_spinlock_alloc_init(void)
 {
     hax_spinlock *lock;

--- a/windows/hax_host_mem.c
+++ b/windows/hax_host_mem.c
@@ -32,7 +32,7 @@
 #include "../include/hax.h"
 #include "../core/include/paging.h"
 
-int hax_pin_user_pages(uint64 start_uva, uint64 size, hax_memdesc_user *memdesc)
+int hax_pin_user_pages(uint64_t start_uva, uint64_t size, hax_memdesc_user *memdesc)
 {
     PMDL pmdl = NULL;
 
@@ -82,11 +82,11 @@ int hax_unpin_user_pages(hax_memdesc_user *memdesc)
     return 0;
 }
 
-uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset)
+uint64_t hax_get_pfn_user(hax_memdesc_user *memdesc, uint64_t uva_offset)
 {
     PMDL pmdl = NULL;
     PPFN_NUMBER ppfn = NULL;
-    uint64 len;
+    uint64_t len;
 
     if (!memdesc) {
         hax_error("%s: memdesc == NULL\n", __func__);
@@ -114,15 +114,15 @@ uint64 hax_get_pfn_user(hax_memdesc_user *memdesc, uint64 uva_offset)
         return INVALID_PFN;
     }
 
-    return (uint64)ppfn[uva_offset >> PG_ORDER_4K];
+    return (uint64_t)ppfn[uva_offset >> PG_ORDER_4K];
 }
 
-void * hax_map_user_pages(hax_memdesc_user *memdesc, uint64 uva_offset,
-                          uint64 size, hax_kmap_user *kmap)
+void * hax_map_user_pages(hax_memdesc_user *memdesc, uint64_t uva_offset,
+                          uint64_t size, hax_kmap_user *kmap)
 {
     ULONG base_size;
-    uint64 uva_offset_low, uva_offset_high;
-    uint64 base_uva, start_uva;
+    uint64_t uva_offset_low, uva_offset_high;
+    uint64_t base_uva, start_uva;
     PMDL pmdl;
     PVOID kva;
 
@@ -153,7 +153,7 @@ void * hax_map_user_pages(hax_memdesc_user *memdesc, uint64 uva_offset,
     }
 
     // Start of the underlying UVA range
-    base_uva = (uint64)MmGetMdlVirtualAddress(memdesc->pmdl);
+    base_uva = (uint64_t)MmGetMdlVirtualAddress(memdesc->pmdl);
     // Start of the UVA subrange
     start_uva = base_uva + uva_offset_low;
     // Recalculate the size of the UVA subrange
@@ -196,7 +196,7 @@ int hax_unmap_user_pages(hax_kmap_user *kmap)
     return 0;
 }
 
-int hax_alloc_page_frame(uint8 flags, hax_memdesc_phys *memdesc)
+int hax_alloc_page_frame(uint8_t flags, hax_memdesc_phys *memdesc)
 {
     PHYSICAL_ADDRESS low_addr, high_addr, skip_bytes;
     ULONG options;
@@ -212,7 +212,7 @@ int hax_alloc_page_frame(uint8 flags, hax_memdesc_phys *memdesc)
     }
 
     low_addr.QuadPart = 0;
-    high_addr.QuadPart = (int64)-1;
+    high_addr.QuadPart = (int64_t)-1;
     skip_bytes.QuadPart = 0;
     // TODO: MM_ALLOCATE_NO_WAIT?
     options = MM_ALLOCATE_FULLY_REQUIRED;
@@ -247,7 +247,7 @@ int hax_free_page_frame(hax_memdesc_phys *memdesc)
     return 0;
 }
 
-uint64 hax_get_pfn_phys(hax_memdesc_phys *memdesc)
+uint64_t hax_get_pfn_phys(hax_memdesc_phys *memdesc)
 {
     PPFN_NUMBER pfns;
 
@@ -289,7 +289,7 @@ void * hax_get_kva_phys(hax_memdesc_phys *memdesc)
     return kva;
 }
 
-void * hax_map_page_frame(uint64 pfn, hax_kmap_phys *kmap)
+void * hax_map_page_frame(uint64_t pfn, hax_kmap_phys *kmap)
 {
     PHYSICAL_ADDRESS addr;
     PVOID kva;

--- a/windows/hax_mem_alloc.c
+++ b/windows/hax_mem_alloc.c
@@ -143,7 +143,7 @@ struct hax_page * hax_alloc_pages(int order, uint32_t flags, bool vmap)
     if (!ppage->kva)
         goto error;
     ppage->pmdl = pmdl;
-    ppage->pa = ((uint64)(MmGetMdlPfnArray(pmdl)[0])) << 12;
+    ppage->pa = ((uint64_t)(MmGetMdlPfnArray(pmdl)[0])) << 12;
 #else
     /*
      * According to WDK, MmAllocateContiguousMemory always returns page-aligned

--- a/windows/hax_mem_alloc.c
+++ b/windows/hax_mem_alloc.c
@@ -83,7 +83,7 @@ void * hax_vmap(hax_pa_t pa, uint32_t size)
     PHYSICAL_ADDRESS phys_addr;
     phys_addr.QuadPart = pa;
 
-    if ((pa & page_mask) + size > page_size) {
+    if ((pa & (PAGE_SIZE - 1)) + size > PAGE_SIZE) {
         hax_warning("hax_vmap can't handle cross-page case!\n");
         return NULL;
     }
@@ -105,7 +105,7 @@ struct hax_page * hax_alloc_pages(int order, uint32_t flags, bool vmap)
 {
     struct hax_page *ppage = NULL;
     PMDL pmdl = NULL;
-    uint64_t length = (1 << order) * page_size;
+    uint64_t length = (1 << order) * PAGE_SIZE;
     PHYSICAL_ADDRESS high_addr, low_addr, skip_bytes;
 #ifdef MDL_HAX_PAGE
     ULONG options;
@@ -206,17 +206,17 @@ hax_pfn_t hax_page2pfn(struct hax_page *page)
 {
     if (!page)
         return 0;
-    return page->pa >> page_shift;
+    return page->pa >> PAGE_SHIFT;
 }
 
 void hax_clear_page(struct hax_page *page)
 {
-    memset((void*)page->kva, 0, 1 << page_shift);
+    memset((void*)page->kva, 0, 1 << PAGE_SHIFT);
 }
 
 void hax_set_page(struct hax_page *page)
 {
-    memset((void*)page->kva, 0xff, 1 << page_shift);
+    memset((void*)page->kva, 0xff, 1 << PAGE_SHIFT);
 }
 
 /* Initialize memory allocation related structures */

--- a/windows/hax_mem_alloc.c
+++ b/windows/hax_mem_alloc.c
@@ -211,12 +211,12 @@ hax_pfn_t hax_page2pfn(struct hax_page *page)
 
 void hax_clear_page(struct hax_page *page)
 {
-    memset((void*)page->kva, 0, 1 << PAGE_SHIFT);
+    memset((void*)page->kva, 0, PAGE_SIZE);
 }
 
 void hax_set_page(struct hax_page *page)
 {
-    memset((void*)page->kva, 0xff, 1 << PAGE_SHIFT);
+    memset((void*)page->kva, 0xff, PAGE_SIZE);
 }
 
 /* Initialize memory allocation related structures */

--- a/windows/hax_mm.c
+++ b/windows/hax_mm.c
@@ -74,7 +74,7 @@ int hax_valid_uva(uint64_t uva, uint64_t size)
 {
     return 1;
     try {
-        ProbeForRead(&uva, size, page_size);
+        ProbeForRead(&uva, size, PAGE_SIZE);
     } except (EXCEPTION_EXECUTE_HANDLER) {
         return 0;
     }
@@ -193,7 +193,7 @@ uint64_t get_hpfn_from_pmem(struct hax_vcpu_mem *pmem, uint64_t va)
             if (kphys.QuadPart == 0)
                 hax_error("kva phys is 0\n");
             else
-                return kphys.QuadPart >> page_shift;
+                return kphys.QuadPart >> PAGE_SHIFT;
         } else {
             unsigned long long index = 0;
             PMDL pmdl = NULL;
@@ -201,12 +201,12 @@ uint64_t get_hpfn_from_pmem(struct hax_vcpu_mem *pmem, uint64_t va)
 
             pmdl = ((struct windows_vcpu_mem *)(pmem->hinfo))->pmdl;
             ppfnnum = MmGetMdlPfnArray(pmdl);
-            index = (va -(pmem->uva))/page_size;
+            index = (va - (pmem->uva)) / PAGE_SIZE;
             return ppfnnum[index];
         }
     }
 
-    return phys.QuadPart >> page_shift;
+    return phys.QuadPart >> PAGE_SHIFT;
 }
 
 uint64_t hax_get_memory_threshold(void)


### PR DESCRIPTION
This patch allows for easier portability of HAXM to other platforms (see #108).
Builds successfully under Windows (32-bit and 64-bit configurations) and MacOS.

## Changes

Main changes are:

- **Normalized casing**: `s/ASSERT/assert`, `s/TRUE/true`, `s/FALSE/false`, since it was inconsistent (both uppercase and lowercase variants were used across the codebase).
- **Normalized integer types**: The codebase mixes (u)intN_t and (u)intN. This commit picks the former variant and consistently use it. Unnecessary typedef's to the latter variant are removed.
- **Fixed missing declarations**: Defined helper functions and macros to fix errors caused by undeclared non-standard functions, e.g.: `min`, `max`.
- **Generalized page-related constants**: Platform-specific headers, e.g. `hax_windows.h` defined page-related constants such as `page_size` and `page_shift` that are identical in all systems since they are unique to the x86 architecture. They were moved to`hax_types.h`.
- **Custom arch/compiler/platform macros**: Created unique `HAX_ARCH_*`, `HAX_COMPILER_*`, `HAX_PLATFORM_*` macros: The goal is avoiding dependance in compiler/platform-specific macros throughout the codebase by creating custom macros declared at a single location.
- **Fixed function prototypes**: Changing `function()` to `function(void)`, fixing `-Wstrict-prototypes`.

Full information in the messages of the individual commits.