### PR TITLE
haxm debugging feature improvement

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -607,6 +607,7 @@ uint32_t load_vmcs(struct vcpu_t *vcpu, preempt_flag *flags)
     if (vcpu) {
         vcpu->is_vmcs_loaded = 1;
         cpu_data->current_vcpu = vcpu;
+        vcpu->prev_cpu_id = vcpu->cpu_id;
         vcpu->cpu_id = hax_cpuid();
     }
 

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -83,6 +83,7 @@ struct hstate {
     uint64_t dr2;
     uint64_t dr3;
     uint64_t dr6;
+    uint64_t dr7;
 };
 
 struct hstate_compare {

--- a/core/include/ia32_defs.h
+++ b/core/include/ia32_defs.h
@@ -31,6 +31,8 @@
 #ifndef HAX_CORE_IA32_DEFS_H_
 #define HAX_CORE_IA32_DEFS_H_
 
+#include "../../include/hax_types.h"
+
 #define IA32_FXSAVE_SIZE 512
 
 enum {
@@ -65,9 +67,34 @@ enum {
 
 enum {
     DR6_BD          = (1 << 13),
+    DR7_L0          = (1 << 0),
+    DR7_G0          = (1 << 1),
+    DR7_L1          = (1 << 2),
+    DR7_G1          = (1 << 3),
+    DR7_L2          = (1 << 4),
+    DR7_G2          = (1 << 5),
+    DR7_L3          = (1 << 6),
+    DR7_G3          = (1 << 7),
     DR7_GD          = (1 << 13),
-    DR7_SETBITS     = (1 << 10)
 };
+#define    DR6_SETBITS          0xFFFF0FF0
+#define    DR7_SETBITS          (1 << 10)
+#define    HBREAK_ENABLED_MASK  (DR7_L0 | DR7_G0 | DR7_L1 | DR7_G1 | \
+                                 DR7_L2 | DR7_G2 | DR7_L3 | DR7_G3)
+
+/*
+ * According to SDM Vol 3B 17.2.6, DR6/7 high 32 bits should only be set to
+ * 0 in 64 bits mode. Reserved bits should be 1.
+ */
+static inline uint64_t fix_dr6(uint64_t val)
+{
+    return (val & 0xffffffff) | DR6_SETBITS;
+}
+
+static inline uint64_t fix_dr7(uint64_t val)
+{
+    return (val & 0xffffffff) | DR7_SETBITS;
+}
 
 enum {
     IA32_P5_MC_ADDR              = 0x0,

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -146,6 +146,8 @@ struct mmio_fetch_cache {
 struct vcpu_t {
     uint16_t vcpu_id;
     uint16_t cpu_id;
+    // Sometimes current thread might be migrated to other core.
+    uint16_t prev_cpu_id;
     /*
      * VPID: Virtual Processor Identifier
      * VPIDs provide a way for software to identify to the processor
@@ -189,7 +191,9 @@ struct vcpu_t {
         uint64_t vmcs_pending_entry_instr_length : 1;
         uint64_t vmcs_pending_entry_intr_info    : 1;
         uint64_t vmcs_pending_guest_cr3          : 1;
-        uint64_t padding                         : 53;
+        uint64_t debug_control_dirty             : 1;
+        uint64_t dr_dirty                        : 1;
+        uint64_t padding                         : 51;
     };
 
     /* For TSC offseting feature*/


### PR DESCRIPTION
This change is to improve robustness and performance for debug
feature(#81). DR registers are loaded to guest only if they are
updated or current thread is migrated to other CPU core. Host
DRs will not be saved and restored unless host process (QEMU)
is debugged with hardware breakpoint.

When a VCPU is being debugged by the host using HW breakpoint,
prevent its DR registers from being tampered with by the guest
OS or by SET_REGS ioctl.

Verified:
 - Guest gdb only;
 - QEMU gdb (debugging guest from host) only;
 - Starting guest gdb, then using QEMU gdb to debug;
 - Host debugging QEMU + Guest gdb;
 - Host debugging QEMU + QEMU gdb;
 - Host debugging QEMU + QEMU gdb + Guest gdb
   QEMU gdb works, and guest gdb reports app crash. Please refer
   to known issues

Known issue:
 - Guest gdb might report app crash When QEMU gdb is enabled
   This is probabaly because existed guest DR state is discarded
   as soon as QEMU gdb enables hardware breakpoint.

Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>