### PR TITLE
Added TravisCI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: c
+
+matrix:
+  include:
+    - name: "haxm-darwin"
+      os: osx
+      osx_image: xcode10
+      addons:
+        homebrew:
+          packages:
+            - nasm
+      script:
+        - cd platforms/darwin
+        - xcodebuild -configuration Debug -sdk macosx10.14
+
+  exclude: # TODO: Currently TravisCI does not support full VS/EWDK on Windows
+    - name: "haxm-windows"
+      os: windows
+      install:
+        - choco install -y nuget.commandline
+        - choco install -y windowsdriverkit10
+      script:
+        - cd platforms/windows
+        - nuget restore
+        - export PATH="$PATH:/c/Program Files (x86)/Microsoft Visual Studio/Installer/"
+        - export MSVC=$(vswhere -latest -products "*" -requires Microsoft.Component.MSBuild -property installationPath)
+        - export MSVC=$(echo /$MSVC | sed -e 's/\\/\//g' -e 's/://')
+        - export PATH="$PATH:$MSVC/MSBuild/15.0/Bin/"
+        - MSBuild.exe haxm.sln //p:Configuration="Debug" //p:Platform="x64"


### PR DESCRIPTION
Based on the discussion at https://github.com/intel/haxm/pull/108#issuecomment-430210463, I've prepared a TravisCI configuration script for HAXM.

This should be extremely helpful to review pull requests. For now it only checks for successful builds, but we can extend it by checking the emulator unit tests, or even integration tests, such as launching a VM (assuming the hardware/hypervisor used in TravisCI servers allows it).

Windows support is very recent (barely two weeks!), and right now they support only Visual Studio 2017 build tools, which apparently is not enough to build HAXM. However I've tested the script locally, and it should work once they provide a proper Visual Studio installation, which is likely. If you want to remove the Windows script in the meantime, let me know (I can add it as a comment to this PR until its ready).

EDIT: It seems https://github.com/intel is already integrated with TravisCI (see badges below). That really helps, and totally makes this choice even more convenient than alternatives (e.g. AppVeyor).