### PR TITLE
avoid unnecessary load_vmcs calls in VM exit

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -480,6 +480,10 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
                 vcpu, VM_EXIT_INFO_IDT_VECTORING);
         vmx(vcpu, exit_instr_length) = vmread(
                 vcpu, VM_EXIT_INFO_INSTRUCTION_LENGTH);
+        vmx(vcpu, exit_gpa) = vmread(
+                vcpu, VM_EXIT_INFO_GUEST_PHYSICAL_ADDRESS);
+        vmx(vcpu, interruptibility_state).raw = vmread(
+                vcpu, GUEST_INTERRUPTIBILITY);
 
         state->_rflags = vmread(vcpu, GUEST_RFLAGS);
         state->_rsp = vmread(vcpu, GUEST_RSP);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -98,6 +98,8 @@ struct vcpu_vmx_data {
     exit_reason_t exit_reason;
     exit_qualification_t exit_qualification;
     interruptibility_state_t interruptibility_state;
+
+    uint64_t exit_gpa;
 };
 
 /* Information saved by instruction decoder and used by post-MMIO handler */
@@ -193,7 +195,12 @@ struct vcpu_t {
         uint64_t vmcs_pending_guest_cr3          : 1;
         uint64_t debug_control_dirty             : 1;
         uint64_t dr_dirty                        : 1;
-        uint64_t padding                         : 51;
+        uint64_t rflags_dirty                    : 1;
+        uint64_t rip_dirty                       : 1;
+        uint64_t fs_base_dirty                   : 1;
+        uint64_t interruptibility_dirty          : 1;
+        uint64_t pcpu_ctls_dirty                 : 1;
+        uint64_t padding                         : 46;
     };
 
     /* For TSC offseting feature*/

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -125,7 +125,7 @@ uint hax_intr_is_blocked(struct vcpu_t *vcpu)
     if (!(state->_eflags & EFLAGS_IF))
         return 1;
 
-    intr_status = vmread(vcpu, GUEST_INTERRUPTIBILITY);
+    intr_status = vmx(vcpu, interruptibility_state).raw;
     if (intr_status & 3)
         return 1;
     return 0;


### PR DESCRIPTION
vmexit handler often needs some VMCS information such as guest
rip, physical address which causes vmexit. To read these
fields from VMCS or to write them back to VMCS, it needs to call
VMREAD and VMWRITE instructions. These two instructions require
the entire VMCS region to be loaded into memory, reading or
writing a VMCS field via vmread() and vmwrite() may incur calls
to load_vmcs() and put_vmcs(), which can have a non-negligible
overhead. If the VM exit handler needs to read/write multiple
VMCS fields, it can save time by merging all the load_vmcs()
calls as well as the put_vmcs() calls.

This change is to optimize vmexit handler performance by moving
frequently used VMCS fields vmread/vmwrite to "vmcs loaded"
context. For VMCS fields which have both read and write access,
a dirty flag is added to mark it should be write back or not
during loading guest state.

In addition, removed unused advance_rip_step function.

Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>