### PR TITLE
Added Windows to TravisCI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
         - cd platforms/linux
         - make -j$(nproc)
 
-  exclude: # TODO: Currently TravisCI does not support full VS/EWDK on Windows
     - name: "haxm-windows"
       os: windows
       install:
@@ -40,4 +39,9 @@ matrix:
         - export MSVC=$(vswhere -latest -products "*" -requires Microsoft.Component.MSBuild -property installationPath)
         - export MSVC=$(echo /$MSVC | sed -e 's/\\/\//g' -e 's/://')
         - export PATH="$PATH:$MSVC/MSBuild/15.0/Bin/"
-        - MSBuild.exe haxm.sln //p:Configuration="Debug" //p:Platform="x64"
+        # TODO: Remove the following hack when no longer needed.
+        # NOTE: Officially WDK does not support VS Build Tools, only regular VS/EWDK installations,
+        #       but since those are not supported by TravisCI, we need to install targets manually.
+        - unzip "/c/Program Files (x86)/Windows Kits/10/Vsix/WDK.vsix" -d wdk
+        - cp -R wdk/\$VCTargets/* "$MSVC/Common7/IDE/VC/VCTargets"
+        - MSBuild.exe haxm-windows.vcxproj //p:Configuration="Debug" //p:Platform="x64"


### PR DESCRIPTION
Although TravisCI doesn't support regular VS/EWDK installations yet, due to lack of early-access features and the impossibility of fetching huge dependencies at build-time, I found a way of integrating the WDK into Visual Studio 2017 Build Tools. Of course, this is rather a hack, but works surprisingly stable. The issue has been reported as well, and it's being considered for a future WDK:
- https://social.msdn.microsoft.com/Forums/windowshardware/en-US/efe5f9f8-c32d-4a25-87e2-abbe711dadbb/no-wdk-support-for-visual-studio-2017-build-tools?forum=wdk

Not sure what will happen first: (1) TravisCI pre-installing VS/EWDK or (2) WDK officially supporting VS2017 Build Tools, but in the meantime we can finally test HAXM on the 3 primary platforms. :-)

![image](https://user-images.githubusercontent.com/5306886/48517278-13b90180-e866-11e8-8754-81e41e9ed4b1.png)


Signed-off-by: Alexandro Sanchez Bach <asanchez@kryptoslogic.com>