### PR TITLE
Rename typename cpuid_t to hax_cpuid_t

### DIFF
--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -44,7 +44,7 @@
 struct vcpu_t;
 struct vcpu_state_t;
 
-typedef uint32_t cpuid_t;  // CPU identifier
+typedef uint32_t hax_cpuid_t;  // CPU identifier
 
 #define NR_HMSR 6
 
@@ -101,7 +101,7 @@ struct per_cpu_data {
     struct hax_page    *vmcs_page;
     struct vcpu_t      *current_vcpu;
     paddr_t            other_vmcs;
-    cpuid_t            cpu_id;
+    hax_cpuid_t        cpu_id;
     uint16_t           vmm_flag;
     uint16_t           nested;
     mword              host_cr4_vmxe;


### PR DESCRIPTION
This removes type clash with NetBSD kernel internals.