### PR TITLE
Rename typename vaddr_t to hax_vaddr_t

### DIFF
--- a/core/include/paging.h
+++ b/core/include/paging.h
@@ -70,7 +70,7 @@ static hax_paddr_t get_pageoffs(hax_paddr_t p, hax_paddr_t o, uint order)
     return ((~(uint64_t)0 << order) & p) | (~(~(uint64_t)0 << order) & o);
 }
 
-static hax_paddr_t get_pagebase(vaddr_t p, uint order)
+static hax_paddr_t get_pagebase(hax_vaddr_t p, uint order)
 {
     return (~(uint64_t)0 << order) & p;
 }
@@ -252,12 +252,12 @@ static inline uint pte32_get_idxmask(uint lvl)
     return 0x3ff;
 }
 
-static inline uint pte32_get_idx(uint lvl, vaddr_t va)
+static inline uint pte32_get_idx(uint lvl, hax_vaddr_t va)
 {
     return (va >> pte32_get_idxbit(lvl)) & pte32_get_idxmask(lvl);
 }
 
-static inline uint pae_get_idx(uint lvl, vaddr_t va)
+static inline uint pae_get_idx(uint lvl, hax_vaddr_t va)
 {
     return (va >> (12 + 9 * lvl)) & 0x1ff;
 }
@@ -430,7 +430,7 @@ static inline uint pte64_get_idxmask(uint lvl)
     return 0x1ff;
 }
 
-static inline uint pte64_get_idx(uint lvl, vaddr_t va)
+static inline uint pte64_get_idx(uint lvl, hax_vaddr_t va)
 {
     return (va >> pte64_get_idxbit(lvl)) & pte64_get_idxmask(lvl);
 }

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -56,7 +56,7 @@ struct gstate {
 };
 
 struct cvtlb {
-    vaddr_t va;
+    hax_vaddr_t va;
     hax_paddr_t ha;
     uint64_t flags;
     uint guest_order;
@@ -116,7 +116,7 @@ struct vcpu_post_mmio {
         /* Index to the register to write to (for VCPU_POST_MMIO_WRITE_REG) */
         uint8_t reg_index;
         /* GVA to write to (for VCPU_POST_MMIO_WRITE_MEM) */
-        vaddr_t va;
+        hax_vaddr_t va;
     };
     /* How to manipulate hax_fastmmio.value before use by |op| */
     enum {

--- a/core/include/vtlb.h
+++ b/core/include/vtlb.h
@@ -65,7 +65,7 @@ typedef enum mmu_mode {
 typedef uint32_t pagemode_t;
 
 typedef struct vtlb {
-    vaddr_t va;
+    hax_vaddr_t va;
     hax_paddr_t ha;
     uint64_t flags;
     uint guest_order;
@@ -95,19 +95,19 @@ typedef struct hax_mmu {
 uint64_t vtlb_get_cr3(struct vcpu_t *vcpu);
 
 void vcpu_invalidate_tlb(struct vcpu_t *vcpu, bool global);
-void vcpu_invalidate_tlb_addr(struct vcpu_t *vcpu, vaddr_t va);
+void vcpu_invalidate_tlb_addr(struct vcpu_t *vcpu, hax_vaddr_t va);
 
 uint vcpu_vtlb_alloc(struct vcpu_t *vcpu);
 void vcpu_vtlb_free(struct vcpu_t *vcpu);
 
 bool handle_vtlb(struct vcpu_t *vcpu);
 
-uint vcpu_translate(struct vcpu_t *vcpu, vaddr_t va, uint access, hax_paddr_t *pa,
+uint vcpu_translate(struct vcpu_t *vcpu, hax_vaddr_t va, uint access, hax_paddr_t *pa,
                     uint64_t *len, bool update);
 
-uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr, void *dst,
+uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, hax_vaddr_t addr, void *dst,
                                uint32_t dst_buflen, uint32_t size, uint flag);
-uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, vaddr_t addr,
+uint32_t vcpu_write_guest_virtual(struct vcpu_t *vcpu, hax_vaddr_t addr,
                                 uint32_t dst_buflen, const void *src, uint32_t size,
                                 uint flag);
 

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -3050,7 +3050,7 @@ static int handle_string_io(struct vcpu_t *vcpu, exit_qualification_t *qual,
     struct vcpu_state_t *state = vcpu->state;
     uint64_t count, total_size;
     uint elem_size, n, copy_size;
-    vaddr_t gla, start_gva;
+    hax_vaddr_t gla, start_gva;
 
     // 1 indicates string I/O (i.e. OUTS or INS)
     htun->io._flags = 1;

--- a/include/hax_interface.h
+++ b/include/hax_interface.h
@@ -125,7 +125,7 @@ struct hax_tunnel {
             uint8_t _pad0;
             uint16_t _pad1;
             uint32_t _pad2;
-            vaddr_t _vaddr;
+            hax_vaddr_t _vaddr;
         } io;
         struct {
             hax_paddr_t gla;

--- a/include/hax_types.h
+++ b/include/hax_types.h
@@ -97,6 +97,6 @@
 typedef uint64_t hax_pa_t;
 typedef uint64_t hax_pfn_t;
 typedef uint64_t hax_paddr_t;
-typedef uint64_t vaddr_t;
+typedef uint64_t hax_vaddr_t;
 
 #endif  // HAX_TYPES_H_


### PR DESCRIPTION
This removes type clash with NetBSD kernel internals.