### PR TITLE
Optimizing VMCS reads/writes with a new cache implementation

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -312,36 +312,6 @@ vmx_result_t cpu_vmx_run(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     return result;
 }
 
-void vcpu_handle_vmcs_pending(struct vcpu_t *vcpu)
-{
-    if (!vcpu || !vcpu->vmcs_pending)
-        return;
-    if (vcpu->vmcs_pending_entry_error_code) {
-        vmwrite(vcpu, VMX_ENTRY_EXCEPTION_ERROR_CODE,
-                vmx(vcpu, entry_exception_error_code));
-        vcpu->vmcs_pending_entry_error_code = 0;
-    }
-
-    if (vcpu->vmcs_pending_entry_instr_length) {
-        vmwrite(vcpu, VMX_ENTRY_INSTRUCTION_LENGTH,
-                vmx(vcpu, entry_instr_length));
-        vcpu->vmcs_pending_entry_instr_length = 0;
-    }
-
-    if (vcpu->vmcs_pending_entry_intr_info) {
-        vmwrite(vcpu, VMX_ENTRY_INTERRUPT_INFO,
-                vmx(vcpu, entry_intr_info).raw);
-        vcpu->vmcs_pending_entry_intr_info = 0;
-    }
-
-    if (vcpu->vmcs_pending_guest_cr3) {
-        vmwrite(vcpu, GUEST_CR3, vtlb_get_cr3(vcpu));
-        vcpu->vmcs_pending_guest_cr3 = 0;
-    }
-    vcpu->vmcs_pending = 0;
-    return;
-}
-
 /* Return the value same as ioctl value */
 int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
@@ -416,16 +386,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 
         vmx(vcpu, exit_qualification).raw = vmread(
                 vcpu, VM_EXIT_INFO_QUALIFICATION);
-        vmx(vcpu, exit_intr_info).raw = vmread(
-                vcpu, VM_EXIT_INFO_INTERRUPT_INFO);
-        vmx(vcpu, exit_exception_error_code) = vmread(
-                vcpu, VM_EXIT_INFO_EXCEPTION_ERROR_CODE);
-        vmx(vcpu, exit_idt_vectoring) = vmread(
-                vcpu, VM_EXIT_INFO_IDT_VECTORING);
-        vmx(vcpu, exit_instr_length) = vmread(
-                vcpu, VM_EXIT_INFO_INSTRUCTION_LENGTH);
-        vmx(vcpu, exit_gpa) = vmread(
-                vcpu, VM_EXIT_INFO_GUEST_PHYSICAL_ADDRESS);
         vmx(vcpu, interruptibility_state).raw = vmread(
                 vcpu, GUEST_INTERRUPTIBILITY);
 

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -313,7 +313,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     vmx_result_t res = 0;
     int ret;
     preempt_flag flags;
-    struct vcpu_state_t *state = vcpu->state;
     uint32_t vmcs_err = 0;
 
     while (1) {
@@ -367,7 +366,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
             return -EINVAL;
         }
 
-        exit_reason.raw = vmread(vcpu, VM_EXIT_INFO_REASON);
+        exit_reason.raw = vmcs_read(vcpu, VM_EXIT_INFO_REASON);
         hax_debug("....exit_reason.raw %x, cpu %d %d\n", exit_reason.raw,
                   vcpu->cpu_id, hax_cpuid());
 
@@ -376,11 +375,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
          * This should be changed later after get better idea
          */
         hax_handle_idt_vectoring(vcpu);
-
-        vmx(vcpu, exit_qualification).raw = vmread(
-                vcpu, VM_EXIT_INFO_QUALIFICATION);
-        vmx(vcpu, interruptibility_state).raw = vmread(
-                vcpu, GUEST_INTERRUPTIBILITY);
 
         vmread_cr(vcpu);
 
@@ -599,7 +593,7 @@ static void cpu_vmentry_failed(struct vcpu_t *vcpu, vmx_result_t result)
 
     //dump_vmcs();
 
-    reason = vmread(vcpu, VM_EXIT_INFO_REASON);
+    reason = vmcs_read(vcpu, VM_EXIT_INFO_REASON);
     if (result == VMX_FAIL_VALID) {
         error = vmread(vcpu, VMX_INSTRUCTION_ERROR_CODE);
         hax_error("VMfailValid. Prev exit: %llx. Error code: %llu (%s)\n",

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -353,11 +353,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
          */
         hax_handle_idt_vectoring(vcpu);
 
-        if (vcpu->nr_pending_intrs > 0 || hax_intr_is_blocked(vcpu))
-            htun->ready_for_interrupt_injection = 0;
-        else
-            htun->ready_for_interrupt_injection = 1;
-
         vcpu->cur_state = GS_STALE;
         vmcs_err = put_vmcs(vcpu, &flags);
         if (vmcs_err) {

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -382,8 +382,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
         vmx(vcpu, interruptibility_state).raw = vmread(
                 vcpu, GUEST_INTERRUPTIBILITY);
 
-        state->_rflags = vmread(vcpu, GUEST_RFLAGS);
-        state->_rsp = vmread(vcpu, GUEST_RSP);
         vmread_cr(vcpu);
 
         if (vcpu->nr_pending_intrs > 0 || hax_intr_is_blocked(vcpu))

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -386,9 +386,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 
         state->_rflags = vmread(vcpu, GUEST_RFLAGS);
         state->_rsp = vmread(vcpu, GUEST_RSP);
-        VMREAD_SEG(vcpu, CS, state->_cs);
-        VMREAD_SEG(vcpu, DS, state->_ds);
-        VMREAD_SEG(vcpu, ES, state->_es);
         vmread_cr(vcpu);
 
         if (vcpu->nr_pending_intrs > 0 || hax_intr_is_blocked(vcpu))

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -375,8 +375,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
          * reason is, we have no schedule hook to get notified of preemption
          * This should be changed later after get better idea
          */
-        vcpu->state->_rip = vmread(vcpu, GUEST_RIP);
-
         hax_handle_idt_vectoring(vcpu);
 
         vmx(vcpu, exit_qualification).raw = vmread(
@@ -599,7 +597,7 @@ static void cpu_vmentry_failed(struct vcpu_t *vcpu, vmx_result_t result)
     uint64_t error, reason;
 
     hax_error("VM entry failed: RIP=%08lx\n",
-              (mword)vmread(vcpu, GUEST_RIP));
+              (mword)vmcs_read(vcpu, GUEST_RIP));
 
     //dump_vmcs();
 

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -297,6 +297,8 @@ vmx_result_t cpu_vmx_run(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     compare_host_state(vcpu);
 #endif
 
+    vcpu_vmcs_flush_cache_r(vcpu);
+
     if (result != VMX_SUCCEED) {
         cpu_vmentry_failed(vcpu, result);
         htun->_exit_reason = 0;
@@ -329,7 +331,7 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
             hax_panic_log(vcpu);
             return 0;
         }
-        vcpu_handle_vmcs_pending(vcpu);
+        vcpu_vmcs_flush_cache_w(vcpu);
         vcpu_inject_intr(vcpu, htun);
 
         /* sometimes, the code segment type from qemu can be 10 (code segment),

--- a/core/cpu.c
+++ b/core/cpu.c
@@ -271,19 +271,12 @@ __attribute__ ((__noinline__))
 vmx_result_t cpu_vmx_run(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 {
     vmx_result_t result = 0;
-    mword host_rip;
 
     /* prepare the RIP */
     hax_debug("vm entry!\n");
     vcpu_save_host_state(vcpu);
     hax_disable_irq();
 
-    /*
-     * put the vmwrite before is_running, so that the vcpu->cpu_id is set
-     * when we check vcpu->is_running in vcpu_pause
-     */
-    host_rip = vmx_get_rip();
-    vmwrite(vcpu, HOST_RIP, (mword)host_rip);
     vcpu->is_running = 1;
 #ifdef  DEBUG_HOST_STATE
     vcpu_get_host_state(vcpu, 1);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -68,40 +68,6 @@ struct cvtlb {
 struct hax_mmu;
 struct per_cpu_data;
 
-struct vcpu_vmx_data {
-    uint32_t pin_ctls_base;
-    uint32_t pcpu_ctls_base;
-    uint32_t scpu_ctls_base;
-    uint32_t entry_ctls_base;
-    uint32_t exc_bitmap_base;
-    uint32_t exit_ctls_base;
-
-    uint32_t pin_ctls;
-    uint32_t pcpu_ctls;
-    uint32_t scpu_ctls;
-    uint32_t entry_ctls;
-    uint32_t exc_bitmap;
-    uint32_t exit_ctls;
-
-    uint64_t cr0_mask, cr0_shadow;
-    uint64_t cr4_mask, cr4_shadow;
-    uint32_t entry_exception_vector;
-    uint32_t entry_exception_error_code;
-
-    uint32_t exit_exception_error_code;
-    interruption_info_t exit_intr_info;
-    interruption_info_t entry_intr_info;
-    uint32_t exit_idt_vectoring;
-    uint32_t exit_instr_length;
-    uint32_t entry_instr_length;
-
-    exit_reason_t exit_reason;
-    exit_qualification_t exit_qualification;
-    interruptibility_state_t interruptibility_state;
-
-    uint64_t exit_gpa;
-};
-
 /* Information saved by instruction decoder and used by post-MMIO handler */
 struct vcpu_post_mmio {
     enum {

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -254,4 +254,11 @@ bool vcpu_is_panic(struct vcpu_t *vcpu);
 void hax_panic_vcpu(struct vcpu_t *v, char *fmt, ...);
 #endif
 
+// Extension-specific operations
+
+uint16_t vcpu_get_seg_selector(struct vcpu_t *vcpu, int seg);
+mword vcpu_get_seg_base(struct vcpu_t *vcpu, int seg);
+uint32_t vcpu_get_seg_limit(struct vcpu_t *vcpu, int seg);
+uint32_t vcpu_get_seg_ar(struct vcpu_t *vcpu, int seg);
+
 #endif  // HAX_CORE_VCPU_H_

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -256,6 +256,8 @@ void hax_panic_vcpu(struct vcpu_t *v, char *fmt, ...);
 
 // Extension-specific operations
 
+mword vcpu_get_rflags(struct vcpu_t *vcpu);
+mword vcpu_get_rsp(struct vcpu_t *vcpu);
 mword vcpu_get_rip(struct vcpu_t *vcpu);
 uint16_t vcpu_get_seg_selector(struct vcpu_t *vcpu, int seg);
 mword vcpu_get_seg_base(struct vcpu_t *vcpu, int seg);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -162,7 +162,6 @@ struct vcpu_t {
         uint64_t fs_base_dirty                   : 1;
         uint64_t interruptibility_dirty          : 1;
         uint64_t pcpu_ctls_dirty                 : 1;
-        uint64_t padding                         : 46;
     };
 
     /* For TSC offseting feature*/

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -256,6 +256,7 @@ void hax_panic_vcpu(struct vcpu_t *v, char *fmt, ...);
 
 // Extension-specific operations
 
+mword vcpu_get_rip(struct vcpu_t *vcpu);
 uint16_t vcpu_get_seg_selector(struct vcpu_t *vcpu, int seg);
 mword vcpu_get_seg_base(struct vcpu_t *vcpu, int seg);
 uint32_t vcpu_get_seg_limit(struct vcpu_t *vcpu, int seg);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -256,6 +256,9 @@ void hax_panic_vcpu(struct vcpu_t *v, char *fmt, ...);
 
 // Extension-specific operations
 
+mword vcpu_get_cr0(struct vcpu_t *vcpu);
+mword vcpu_get_cr3(struct vcpu_t *vcpu);
+mword vcpu_get_cr4(struct vcpu_t *vcpu);
 mword vcpu_get_rflags(struct vcpu_t *vcpu);
 mword vcpu_get_rsp(struct vcpu_t *vcpu);
 mword vcpu_get_rip(struct vcpu_t *vcpu);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -154,10 +154,6 @@ struct vcpu_t {
 #define GS_STALE      0
 #define GS_VALID      1
         uint64_t cur_state                       : 1;
-        uint64_t vmcs_pending                    : 1;
-        uint64_t vmcs_pending_entry_error_code   : 1;
-        uint64_t vmcs_pending_entry_instr_length : 1;
-        uint64_t vmcs_pending_entry_intr_info    : 1;
         uint64_t vmcs_pending_guest_cr3          : 1;
         uint64_t debug_control_dirty             : 1;
         uint64_t dr_dirty                        : 1;

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -877,11 +877,6 @@ struct vcpu_vmx_data {
 
     uint64_t cr0_mask, cr0_shadow;
     uint64_t cr4_mask, cr4_shadow;
-    uint32_t entry_exception_vector;
-    uint32_t entry_exception_error_code;
-
-    interruption_info_t entry_intr_info;
-    uint32_t entry_instr_length;
 
     exit_reason_t exit_reason;
     exit_qualification_t exit_qualification;
@@ -914,12 +909,12 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
  */
 #define COMP_R_0(width, name)                                                 \
     static inline COMP_TYPE_##width                                           \
-                  vmcs_read_##name(struct vcpu_vmx_data* vcpu_vmx) {          \
+                  vmcs_read_##name(struct vcpu_vmx_data *vcpu_vmx) {          \
         return vmread(vcpu_vmx->parent, name);                                \
     }
 #define COMP_R_1(width, name)                                                 \
     static inline COMP_TYPE_##width                                           \
-                  vmcs_read_##name(struct vcpu_vmx_data* vcpu_vmx) {          \
+                  vmcs_read_##name(struct vcpu_vmx_data *vcpu_vmx) {          \
         if (vcpu_vmx->vmcs_cache_r.name##_cache)                              \
             return vcpu_vmx->vmcs.name##_value;                               \
         vcpu_vmx->vmcs.name##_value = vmread(vcpu_vmx->parent, name);         \
@@ -932,12 +927,12 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
   * Writes the VMCS-component <name> to the specified VCPU (cached if enabled).
   */
 #define COMP_W_0(width, name)                                                 \
-    static inline void vmcs_write_##name(struct vcpu_vmx_data* vcpu_vmx,      \
+    static inline void vmcs_write_##name(struct vcpu_vmx_data *vcpu_vmx,      \
                                          COMP_TYPE_##width value) {           \
         vmwrite(vcpu_vmx->parent, name, value);                               \
     }
 #define COMP_W_1(width, name)                                                 \
-    static inline void vmcs_write_##name(struct vcpu_vmx_data* vcpu_vmx,      \
+    static inline void vmcs_write_##name(struct vcpu_vmx_data *vcpu_vmx,      \
                                          COMP_TYPE_##width value) {           \
         vcpu_vmx->vmcs.name##_value = value;                                  \
         /*vcpu_vmx->vmcs_cache_r.name##_cache = 1;*/                          \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -338,7 +338,7 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_UL, HOST_IDTR_BASE)                         \
     COMP(0, 0, W_UL, HOST_SYSENTER_ESP)                      \
     COMP(0, 0, W_UL, HOST_SYSENTER_EIP)                      \
-    COMP(0, 0, W_UL, GUEST_RIP)                              \
+    COMP(1, 0, W_UL, GUEST_RIP)                              \
     COMP(0, 0, W_UL, GUEST_RFLAGS)                           \
     COMP(0, 0, W_UL, GUEST_RSP)                              \
     COMP(0, 0, W_UL, GUEST_CR0)                              \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -320,7 +320,7 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_UL, VMX_CR0_READ_SHADOW)                    \
     COMP(0, 0, W_UL, VMX_CR4_READ_SHADOW)                    \
     COMP(0, 0, W_UL, VMX_CR3_TARGET_VAL_BASE)                \
-    COMP(0, 0, W_UL, VM_EXIT_INFO_QUALIFICATION)             \
+    COMP(1, 0, W_UL, VM_EXIT_INFO_QUALIFICATION)             \
     COMP(0, 0, W_UL, VM_EXIT_INFO_IO_ECX)                    \
     COMP(0, 0, W_UL, VM_EXIT_INFO_IO_ESI)                    \
     COMP(0, 0, W_UL, VM_EXIT_INFO_IO_EDI)                    \
@@ -377,7 +377,7 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_32, VMX_CR3_TARGET_COUNT)                   \
     COMP(0, 0, W_32, VMX_PREEMPTION_TIMER)                   \
     COMP(0, 0, W_32, VMX_INSTRUCTION_ERROR_CODE)             \
-    COMP(0, 0, W_32, VM_EXIT_INFO_REASON)                    \
+    COMP(1, 0, W_32, VM_EXIT_INFO_REASON)                    \
     COMP(1, 0, W_32, VM_EXIT_INFO_INTERRUPT_INFO)            \
     COMP(1, 0, W_32, VM_EXIT_INFO_EXCEPTION_ERROR_CODE)      \
     COMP(1, 0, W_32, VM_EXIT_INFO_IDT_VECTORING)             \
@@ -405,7 +405,7 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_32, GUEST_IDTR_LIMIT)                       \
     COMP(0, 0, W_32, GUEST_SYSENTER_CS)                      \
     COMP(0, 0, W_32, GUEST_SMBASE)                           \
-    COMP(0, 0, W_32, GUEST_INTERRUPTIBILITY)                 \
+    COMP(1, 0, W_32, GUEST_INTERRUPTIBILITY)                 \
     COMP(0, 0, W_32, GUEST_ACTIVITY_STATE)                   \
     /* 16-bit components */                                  \
     COMP(0, 0, W_16, VMX_VPID)                               \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -102,6 +102,7 @@ enum {
     VMX_EXIT_XRSTORS                 = 64
 };
 
+// Intel SDM Vol. 3D: Appendix B: Field Encoding in VMCS
 enum component_index_t {
     VMX_PIN_CONTROLS                            = 0x00004000,
     VMX_PRIMARY_PROCESSOR_CONTROLS              = 0x00004002,
@@ -467,6 +468,21 @@ union instruction_info_t {
 
 typedef union instruction_info_t instruction_info_t;
 
+// Intel SDM Vol. 3C: Table 24-3. Format of Interruptibility State
+union interruptibility_state_t {
+    uint32_t raw;
+    struct {
+        uint32_t sti_blocking : 1;
+        uint32_t movss_blocking : 1;
+        uint32_t smi_blocking : 1;
+        uint32_t nmi_blocking : 1;
+        uint32_t reserved : 28;
+    };
+    uint64_t pad;
+} PACKED;
+
+typedef union interruptibility_state_t interruptibility_state_t;
+
 // 64-bit OK
 union interruption_info_t {
     uint32_t raw;
@@ -635,6 +651,40 @@ struct invept_desc {
 
 struct vcpu_state_t;
 struct vcpu_t;
+
+struct vcpu_vmx_data {
+    uint32_t pin_ctls_base;
+    uint32_t pcpu_ctls_base;
+    uint32_t scpu_ctls_base;
+    uint32_t entry_ctls_base;
+    uint32_t exc_bitmap_base;
+    uint32_t exit_ctls_base;
+
+    uint32_t pin_ctls;
+    uint32_t pcpu_ctls;
+    uint32_t scpu_ctls;
+    uint32_t entry_ctls;
+    uint32_t exc_bitmap;
+    uint32_t exit_ctls;
+
+    uint64_t cr0_mask, cr0_shadow;
+    uint64_t cr4_mask, cr4_shadow;
+    uint32_t entry_exception_vector;
+    uint32_t entry_exception_error_code;
+
+    uint32_t exit_exception_error_code;
+    interruption_info_t exit_intr_info;
+    interruption_info_t entry_intr_info;
+    uint32_t exit_idt_vectoring;
+    uint32_t exit_instr_length;
+    uint32_t entry_instr_length;
+
+    exit_reason_t exit_reason;
+    exit_qualification_t exit_qualification;
+    interruptibility_state_t interruptibility_state;
+
+    uint64_t exit_gpa;
+};
 
 vmx_result_t ASMCALL asm_invept(uint type, struct invept_desc *desc);
 vmx_result_t ASMCALL asm_vmclear(const hax_paddr_t *addr_in);

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -344,12 +344,12 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_UL, GUEST_CR0)                              \
     COMP(0, 0, W_UL, GUEST_CR3)                              \
     COMP(0, 0, W_UL, GUEST_CR4)                              \
-    COMP(0, 0, W_UL, GUEST_ES_BASE)                          \
-    COMP(0, 0, W_UL, GUEST_CS_BASE)                          \
-    COMP(0, 0, W_UL, GUEST_SS_BASE)                          \
-    COMP(0, 0, W_UL, GUEST_DS_BASE)                          \
-    COMP(0, 0, W_UL, GUEST_FS_BASE)                          \
-    COMP(0, 0, W_UL, GUEST_GS_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_ES_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_CS_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_SS_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_DS_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_FS_BASE)                          \
+    COMP(1, 0, W_UL, GUEST_GS_BASE)                          \
     COMP(0, 0, W_UL, GUEST_LDTR_BASE)                        \
     COMP(0, 0, W_UL, GUEST_TR_BASE)                          \
     COMP(0, 0, W_UL, GUEST_GDTR_BASE)                        \
@@ -385,20 +385,20 @@ typedef enum component_index_t component_index_t;
     COMP(1, 0, W_32, VM_EXIT_INFO_INSTRUCTION_LENGTH)        \
     COMP(0, 0, W_32, VM_EXIT_INFO_INSTRUCTION_INFO)          \
     COMP(0, 0, W_32, HOST_SYSENTER_CS)                       \
-    COMP(0, 0, W_32, GUEST_ES_AR)                            \
-    COMP(0, 0, W_32, GUEST_CS_AR)                            \
-    COMP(0, 0, W_32, GUEST_SS_AR)                            \
-    COMP(0, 0, W_32, GUEST_DS_AR)                            \
-    COMP(0, 0, W_32, GUEST_FS_AR)                            \
-    COMP(0, 0, W_32, GUEST_GS_AR)                            \
+    COMP(1, 0, W_32, GUEST_ES_AR)                            \
+    COMP(1, 0, W_32, GUEST_CS_AR)                            \
+    COMP(1, 0, W_32, GUEST_SS_AR)                            \
+    COMP(1, 0, W_32, GUEST_DS_AR)                            \
+    COMP(1, 0, W_32, GUEST_FS_AR)                            \
+    COMP(1, 0, W_32, GUEST_GS_AR)                            \
     COMP(0, 0, W_32, GUEST_LDTR_AR)                          \
     COMP(0, 0, W_32, GUEST_TR_AR)                            \
-    COMP(0, 0, W_32, GUEST_ES_LIMIT)                         \
-    COMP(0, 0, W_32, GUEST_CS_LIMIT)                         \
-    COMP(0, 0, W_32, GUEST_SS_LIMIT)                         \
-    COMP(0, 0, W_32, GUEST_DS_LIMIT)                         \
-    COMP(0, 0, W_32, GUEST_FS_LIMIT)                         \
-    COMP(0, 0, W_32, GUEST_GS_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_ES_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_CS_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_SS_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_DS_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_FS_LIMIT)                         \
+    COMP(1, 0, W_32, GUEST_GS_LIMIT)                         \
     COMP(0, 0, W_32, GUEST_LDTR_LIMIT)                       \
     COMP(0, 0, W_32, GUEST_TR_LIMIT)                         \
     COMP(0, 0, W_32, GUEST_GDTR_LIMIT)                       \
@@ -416,12 +416,12 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_16, HOST_GS_SELECTOR)                       \
     COMP(0, 0, W_16, HOST_SS_SELECTOR)                       \
     COMP(0, 0, W_16, HOST_TR_SELECTOR)                       \
-    COMP(0, 0, W_16, GUEST_ES_SELECTOR)                      \
-    COMP(0, 0, W_16, GUEST_CS_SELECTOR)                      \
-    COMP(0, 0, W_16, GUEST_SS_SELECTOR)                      \
-    COMP(0, 0, W_16, GUEST_DS_SELECTOR)                      \
-    COMP(0, 0, W_16, GUEST_FS_SELECTOR)                      \
-    COMP(0, 0, W_16, GUEST_GS_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_ES_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_CS_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_SS_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_DS_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_FS_SELECTOR)                      \
+    COMP(1, 0, W_16, GUEST_GS_SELECTOR)                      \
     COMP(0, 0, W_16, GUEST_LDTR_SELECTOR)                    \
     COMP(0, 0, W_16, GUEST_TR_SELECTOR)                      
 

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -960,7 +960,17 @@ VMCS_COMPS
 #define vmcs_write(vcpu, name, value) \
     vmcs_write_##name(&vcpu->vmx, value)
 
-void vcpu_handle_vmcs_pending(struct vcpu_t *vcpu);
+/**
+ * Flush VMCS read-cache after guest-exit.
+ * @param  vcpu  VCPU object
+ */
+void vcpu_vmcs_flush_cache_r(struct vcpu_t *vcpu);
+
+/**
+ * Flush VMCS write-cache before guest-enter (calling vmwrite if required).
+ * @param  vcpu  VCPU object
+ */
+void vcpu_vmcs_flush_cache_w(struct vcpu_t *vcpu);
 
 #define VMREAD_SEG(vcpu, seg, val)                                 \
         ((val).selector = vmread(vcpu, GUEST_##seg##_SELECTOR),    \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009 Intel Corporation
+ * Copyright (c) 2018 Kryptos Logic
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -256,6 +257,208 @@ enum component_index_t {
 };
 
 typedef enum component_index_t component_index_t;
+
+// VMCS component types
+#define COMP_TYPE_W_16 uint16_t
+#define COMP_TYPE_W_32 uint32_t
+#define COMP_TYPE_W_64 uint64_t
+#ifdef HAX_ARCH_X86_64
+#define COMP_TYPE_W_UL uint64_t
+#else
+#define COMP_TYPE_W_UL uint32_t
+#endif
+
+/**
+ * VMCS Cache
+ * ==========
+ * Stores all VMCS components declared through the macro
+ * COMP(cache_r, cache_w, width, value), with the arguments:
+ * - cache_r: Boolean value to toggle read-cache:
+ *   - 0  Reading cache disabled
+ *   - 1  Reading cache enabled
+ * - cache_w: Boolean value to toggle write-cache:
+ *   - 0  Writing cache disabled
+ *   - 1  Writing cache enabled
+ * - width: Component width.
+ *   - W_16 (0): 16-bit unsigned integer.
+ *   - W_64 (1): 64-bit unsigned integer.
+ *   - W_32 (2): 32-bit unsigned integer.
+ *   - W_UL (3): Natural-width unsigned integer.
+ * - name: Component name, defined as encoding value.
+ *
+ * For optimal memory packing, components should be declared
+ * in the following order: W_64, W_UL, W_32, W_16.
+ */
+#define VMCS_COMPS                                           \
+    /* 64-bit components */                                  \
+    COMP(1, 1, W_64, VMX_IO_BITMAP_A)                        \
+    COMP(0, 0, W_64, VMX_IO_BITMAP_B)                        \
+    COMP(0, 0, W_64, VMX_MSR_BITMAP)                         \
+    COMP(0, 0, W_64, VMX_EXIT_MSR_STORE_ADDRESS)             \
+    COMP(0, 0, W_64, VMX_EXIT_MSR_LOAD_ADDRESS)              \
+    COMP(0, 0, W_64, VMX_ENTRY_MSR_LOAD_ADDRESS)             \
+    COMP(0, 0, W_64, VMX_TSC_OFFSET)                         \
+    COMP(0, 0, W_64, VMX_VAPIC_PAGE)                         \
+    COMP(0, 0, W_64, VMX_APIC_ACCESS_PAGE)                   \
+    COMP(0, 0, W_64, VMX_EPTP)                               \
+    COMP(0, 0, W_64, VM_EXIT_INFO_GUEST_PHYSICAL_ADDRESS)    \
+    COMP(0, 0, W_64, HOST_PAT)                               \
+    COMP(0, 0, W_64, HOST_EFER)                              \
+    COMP(0, 0, W_64, HOST_PERF_GLOBAL_CTRL)                  \
+    COMP(0, 0, W_64, GUEST_VMCS_LINK_PTR)                    \
+    COMP(0, 0, W_64, GUEST_DEBUGCTL)                         \
+    COMP(0, 0, W_64, GUEST_PAT)                              \
+    COMP(0, 0, W_64, GUEST_EFER)                             \
+    COMP(0, 0, W_64, GUEST_PERF_GLOBAL_CTRL)                 \
+    COMP(0, 0, W_64, GUEST_PDPTE0)                           \
+    COMP(0, 0, W_64, GUEST_PDPTE1)                           \
+    COMP(0, 0, W_64, GUEST_PDPTE2)                           \
+    COMP(0, 0, W_64, GUEST_PDPTE3)                           \
+    /* Natural-width components */                           \
+    COMP(0, 0, W_UL, VMX_CR0_MASK)                           \
+    COMP(0, 0, W_UL, VMX_CR4_MASK)                           \
+    COMP(0, 0, W_UL, VMX_CR0_READ_SHADOW)                    \
+    COMP(0, 0, W_UL, VMX_CR4_READ_SHADOW)                    \
+    COMP(0, 0, W_UL, VMX_CR3_TARGET_VAL_BASE)                \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_QUALIFICATION)             \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_IO_ECX)                    \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_IO_ESI)                    \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_IO_EDI)                    \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_IO_EIP)                    \
+    COMP(0, 0, W_UL, VM_EXIT_INFO_GUEST_LINEAR_ADDRESS)      \
+    COMP(0, 0, W_UL, HOST_RIP)                               \
+    COMP(0, 0, W_UL, HOST_RSP)                               \
+    COMP(0, 0, W_UL, HOST_CR0)                               \
+    COMP(0, 0, W_UL, HOST_CR3)                               \
+    COMP(0, 0, W_UL, HOST_CR4)                               \
+    COMP(0, 0, W_UL, HOST_FS_BASE)                           \
+    COMP(0, 0, W_UL, HOST_GS_BASE)                           \
+    COMP(0, 0, W_UL, HOST_TR_BASE)                           \
+    COMP(0, 0, W_UL, HOST_GDTR_BASE)                         \
+    COMP(0, 0, W_UL, HOST_IDTR_BASE)                         \
+    COMP(0, 0, W_UL, HOST_SYSENTER_ESP)                      \
+    COMP(0, 0, W_UL, HOST_SYSENTER_EIP)                      \
+    COMP(0, 0, W_UL, GUEST_RIP)                              \
+    COMP(0, 0, W_UL, GUEST_RFLAGS)                           \
+    COMP(0, 0, W_UL, GUEST_RSP)                              \
+    COMP(0, 0, W_UL, GUEST_CR0)                              \
+    COMP(0, 0, W_UL, GUEST_CR3)                              \
+    COMP(0, 0, W_UL, GUEST_CR4)                              \
+    COMP(0, 0, W_UL, GUEST_ES_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_CS_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_SS_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_DS_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_FS_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_GS_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_LDTR_BASE)                        \
+    COMP(0, 0, W_UL, GUEST_TR_BASE)                          \
+    COMP(0, 0, W_UL, GUEST_GDTR_BASE)                        \
+    COMP(0, 0, W_UL, GUEST_IDTR_BASE)                        \
+    COMP(0, 0, W_UL, GUEST_DR7)                              \
+    COMP(0, 0, W_UL, GUEST_PENDING_DBE)                      \
+    COMP(0, 0, W_UL, GUEST_SYSENTER_ESP)                     \
+    COMP(0, 0, W_UL, GUEST_SYSENTER_EIP)                     \
+    /* 32-bit components */                                  \
+    COMP(0, 0, W_32, VMX_PIN_CONTROLS)                       \
+    COMP(0, 0, W_32, VMX_PRIMARY_PROCESSOR_CONTROLS)         \
+    COMP(0, 0, W_32, VMX_SECONDARY_PROCESSOR_CONTROLS)       \
+    COMP(0, 0, W_32, VMX_EXCEPTION_BITMAP)                   \
+    COMP(0, 0, W_32, VMX_PAGE_FAULT_ERROR_CODE_MASK)         \
+    COMP(0, 0, W_32, VMX_PAGE_FAULT_ERROR_CODE_MATCH)        \
+    COMP(0, 0, W_32, VMX_EXIT_CONTROLS)                      \
+    COMP(0, 0, W_32, VMX_EXIT_MSR_STORE_COUNT)               \
+    COMP(0, 0, W_32, VMX_EXIT_MSR_LOAD_COUNT)                \
+    COMP(0, 0, W_32, VMX_ENTRY_CONTROLS)                     \
+    COMP(0, 0, W_32, VMX_ENTRY_MSR_LOAD_COUNT)               \
+    COMP(0, 0, W_32, VMX_ENTRY_INTERRUPT_INFO)               \
+    COMP(0, 0, W_32, VMX_ENTRY_EXCEPTION_ERROR_CODE)         \
+    COMP(0, 0, W_32, VMX_ENTRY_INSTRUCTION_LENGTH)           \
+    COMP(0, 0, W_32, VMX_TPR_THRESHOLD)                      \
+    COMP(0, 0, W_32, VMX_CR3_TARGET_COUNT)                   \
+    COMP(0, 0, W_32, VMX_PREEMPTION_TIMER)                   \
+    COMP(0, 0, W_32, VMX_INSTRUCTION_ERROR_CODE)             \
+    COMP(0, 0, W_32, VM_EXIT_INFO_REASON)                    \
+    COMP(0, 0, W_32, VM_EXIT_INFO_INTERRUPT_INFO)            \
+    COMP(0, 0, W_32, VM_EXIT_INFO_EXCEPTION_ERROR_CODE)      \
+    COMP(0, 0, W_32, VM_EXIT_INFO_IDT_VECTORING)             \
+    COMP(0, 0, W_32, VM_EXIT_INFO_IDT_VECTORING_ERROR_CODE)  \
+    COMP(0, 0, W_32, VM_EXIT_INFO_INSTRUCTION_LENGTH)        \
+    COMP(0, 0, W_32, VM_EXIT_INFO_INSTRUCTION_INFO)          \
+    COMP(0, 0, W_32, HOST_SYSENTER_CS)                       \
+    COMP(0, 0, W_32, GUEST_ES_AR)                            \
+    COMP(0, 0, W_32, GUEST_CS_AR)                            \
+    COMP(0, 0, W_32, GUEST_SS_AR)                            \
+    COMP(0, 0, W_32, GUEST_DS_AR)                            \
+    COMP(0, 0, W_32, GUEST_FS_AR)                            \
+    COMP(0, 0, W_32, GUEST_GS_AR)                            \
+    COMP(0, 0, W_32, GUEST_LDTR_AR)                          \
+    COMP(0, 0, W_32, GUEST_TR_AR)                            \
+    COMP(0, 0, W_32, GUEST_ES_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_CS_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_SS_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_DS_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_FS_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_GS_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_LDTR_LIMIT)                       \
+    COMP(0, 0, W_32, GUEST_TR_LIMIT)                         \
+    COMP(0, 0, W_32, GUEST_GDTR_LIMIT)                       \
+    COMP(0, 0, W_32, GUEST_IDTR_LIMIT)                       \
+    COMP(0, 0, W_32, GUEST_SYSENTER_CS)                      \
+    COMP(0, 0, W_32, GUEST_SMBASE)                           \
+    COMP(0, 0, W_32, GUEST_INTERRUPTIBILITY)                 \
+    COMP(0, 0, W_32, GUEST_ACTIVITY_STATE)                   \
+    /* 16-bit components */                                  \
+    COMP(0, 0, W_16, VMX_VPID)                               \
+    COMP(0, 0, W_16, HOST_CS_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_DS_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_ES_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_FS_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_GS_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_SS_SELECTOR)                       \
+    COMP(0, 0, W_16, HOST_TR_SELECTOR)                       \
+    COMP(0, 0, W_16, GUEST_ES_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_CS_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_SS_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_DS_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_FS_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_GS_SELECTOR)                      \
+    COMP(0, 0, W_16, GUEST_LDTR_SELECTOR)                    \
+    COMP(0, 0, W_16, GUEST_TR_SELECTOR)                      
+
+ // Macros for declaring cache and R/W-flags declarations
+#define COMP_CACHE_R_0(name)
+#define COMP_CACHE_R_1(name) \
+    bool name##_cache : 1;
+#define COMP_CACHE_W_0(name)
+#define COMP_CACHE_W_1(name) \
+    bool name##_dirty : 1;
+
+#define COMP_CACHE_R(cache_r, cache_w, width, name) \
+    COMP_CACHE_R_##cache_r(name)
+#define COMP_CACHE_W(cache_r, cache_w, width, name) \
+    COMP_CACHE_W_##cache_w(name)
+#define COMP_DECLARE(cache_r, cache_w, width, name) \
+    COMP_TYPE_##width name##_value;
+
+// Structures
+struct vmx_vmcs_t {
+#define COMP COMP_DECLARE
+    VMCS_COMPS
+#undef COMP
+};
+
+struct vmx_vmcs_cache_r_t {
+#define COMP COMP_CACHE_R
+    VMCS_COMPS
+#undef COMP
+};
+
+struct vmx_vmcs_cache_w_t {
+    bool dirty : 1;
+#define COMP COMP_CACHE_W
+    VMCS_COMPS
+#undef COMP
+};
 
 // PIN-BASED CONTROLS
 #define EXT_INTERRUPT_EXITING                  0x00000001
@@ -653,6 +856,11 @@ struct vcpu_state_t;
 struct vcpu_t;
 
 struct vcpu_vmx_data {
+    struct vcpu_t *parent;
+    struct vmx_vmcs_t vmcs;
+    struct vmx_vmcs_cache_r_t vmcs_cache_r;
+    struct vmx_vmcs_cache_w_t vmcs_cache_w;
+
     uint32_t pin_ctls_base;
     uint32_t pcpu_ctls_base;
     uint32_t scpu_ctls_base;
@@ -705,6 +913,64 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
                  component_index_t component, uint64_t source_val);
 
 #define vmwrite(vcpu, x, y) vmx_vmwrite(vcpu, #x, x, y)
+
+/**
+ * vmcs_read_<name>
+ * Reads the VMCS-component <name> from the specified VCPU (cached if enabled).
+ */
+#define COMP_R_0(width, name)                                                 \
+    static inline COMP_TYPE_##width                                           \
+                  vmcs_read_##name(struct vcpu_vmx_data* vcpu_vmx) {          \
+        return vmread(vcpu_vmx->parent, name);                                \
+    }
+#define COMP_R_1(width, name)                                                 \
+    static inline COMP_TYPE_##width                                           \
+                  vmcs_read_##name(struct vcpu_vmx_data* vcpu_vmx) {          \
+        if (vcpu_vmx->vmcs_cache_r.name##_cache)                              \
+            return vcpu_vmx->vmcs.name##_value;                               \
+        vcpu_vmx->vmcs.name##_value = vmread(vcpu_vmx->parent, name);         \
+        vcpu_vmx->vmcs_cache_r.name##_cache = 1;                              \
+        return vcpu_vmx->vmcs.name##_value;                                   \
+    }
+
+ /**
+  * vmcs_write_<name>
+  * Writes the VMCS-component <name> to the specified VCPU (cached if enabled).
+  */
+#define COMP_W_0(width, name)                                                 \
+    static inline void vmcs_write_##name(struct vcpu_vmx_data* vcpu_vmx,      \
+                                         COMP_TYPE_##width value) {           \
+        vmwrite(vcpu_vmx->parent, name, value);                               \
+    }
+#define COMP_W_1(width, name)                                                 \
+    static inline void vmcs_write_##name(struct vcpu_vmx_data* vcpu_vmx,      \
+                                         COMP_TYPE_##width value) {           \
+        vcpu_vmx->vmcs.name##_value = value;                                  \
+        vcpu_vmx->vmcs_cache_r.name##_cache = 1;                              \
+        vcpu_vmx->vmcs_cache_w.name##_dirty = 1;                              \
+    }
+
+  // Declarations
+#define COMP_R(cache_r, cache_w, width, name) \
+    COMP_R_##cache_r(width, name);
+#define COMP_W(cache_r, cache_w, width, name) \
+    COMP_W_##cache_w(width, name);
+
+// Helper functions
+#define COMP COMP_R
+VMCS_COMPS
+#undef COMP
+
+#define COMP COMP_W
+VMCS_COMPS
+#undef COMP
+
+#define vmcs_read(vcpu, name) \
+    vmcs_read_##name(&vcpu->vmx)
+#define vmcs_write(vcpu, name, value) \
+    vmcs_write_##name(&vcpu->vmx, value)
+
+void vmcs_write_pending(struct vcpu_t *vcpu);
 
 #define VMREAD_SEG(vcpu, seg, val)                                 \
         ((val).selector = vmread(vcpu, GUEST_##seg##_SELECTOR),    \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -315,8 +315,8 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_64, GUEST_PDPTE2)                           \
     COMP(0, 0, W_64, GUEST_PDPTE3)                           \
     /* Natural-width components */                           \
-    COMP(0, 0, W_UL, VMX_CR0_MASK)                           \
-    COMP(0, 0, W_UL, VMX_CR4_MASK)                           \
+    COMP(1, 0, W_UL, VMX_CR0_MASK)                           \
+    COMP(1, 0, W_UL, VMX_CR4_MASK)                           \
     COMP(0, 0, W_UL, VMX_CR0_READ_SHADOW)                    \
     COMP(0, 0, W_UL, VMX_CR4_READ_SHADOW)                    \
     COMP(0, 0, W_UL, VMX_CR3_TARGET_VAL_BASE)                \
@@ -341,9 +341,9 @@ typedef enum component_index_t component_index_t;
     COMP(1, 0, W_UL, GUEST_RIP)                              \
     COMP(1, 0, W_UL, GUEST_RFLAGS)                           \
     COMP(1, 0, W_UL, GUEST_RSP)                              \
-    COMP(0, 0, W_UL, GUEST_CR0)                              \
-    COMP(0, 0, W_UL, GUEST_CR3)                              \
-    COMP(0, 0, W_UL, GUEST_CR4)                              \
+    COMP(1, 0, W_UL, GUEST_CR0)                              \
+    COMP(1, 0, W_UL, GUEST_CR3)                              \
+    COMP(1, 0, W_UL, GUEST_CR4)                              \
     COMP(1, 0, W_UL, GUEST_ES_BASE)                          \
     COMP(1, 0, W_UL, GUEST_CS_BASE)                          \
     COMP(1, 0, W_UL, GUEST_SS_BASE)                          \

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -339,8 +339,8 @@ typedef enum component_index_t component_index_t;
     COMP(0, 0, W_UL, HOST_SYSENTER_ESP)                      \
     COMP(0, 0, W_UL, HOST_SYSENTER_EIP)                      \
     COMP(1, 0, W_UL, GUEST_RIP)                              \
-    COMP(0, 0, W_UL, GUEST_RFLAGS)                           \
-    COMP(0, 0, W_UL, GUEST_RSP)                              \
+    COMP(1, 0, W_UL, GUEST_RFLAGS)                           \
+    COMP(1, 0, W_UL, GUEST_RSP)                              \
     COMP(0, 0, W_UL, GUEST_CR0)                              \
     COMP(0, 0, W_UL, GUEST_CR3)                              \
     COMP(0, 0, W_UL, GUEST_CR4)                              \

--- a/core/include/vtlb.h
+++ b/core/include/vtlb.h
@@ -100,10 +100,10 @@ void vcpu_invalidate_tlb_addr(struct vcpu_t *vcpu, hax_vaddr_t va);
 uint vcpu_vtlb_alloc(struct vcpu_t *vcpu);
 void vcpu_vtlb_free(struct vcpu_t *vcpu);
 
-bool handle_vtlb(struct vcpu_t *vcpu);
+bool handle_vtlb(struct vcpu_t *vcpu, hax_vaddr_t addr);
 
-uint vcpu_translate(struct vcpu_t *vcpu, hax_vaddr_t va, uint access, hax_paddr_t *pa,
-                    uint64_t *len, bool update);
+uint vcpu_translate(struct vcpu_t *vcpu, hax_vaddr_t va, uint access,
+                    hax_paddr_t *pa, uint64_t *len, bool update);
 
 uint32_t vcpu_read_guest_virtual(struct vcpu_t *vcpu, hax_vaddr_t addr, void *dst,
                                uint32_t dst_buflen, uint32_t size, uint flag);

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -217,21 +217,12 @@ void hax_inject_exception(struct vcpu_t *vcpu, uint8_t vector, uint32_t error_co
         intr_info = (1 << 31) | (EXCEPTION << 8) | vector;
         if (error_code != NO_ERROR_CODE) {
             intr_info |= 1 << 11;
-            if (vector == VECTOR_PF) {
-                vmcs_write(vcpu, VMX_ENTRY_EXCEPTION_ERROR_CODE, error_code);
-            } else {
-                vmwrite(vcpu, VMX_ENTRY_EXCEPTION_ERROR_CODE, error_code);
-            }
+            vmcs_write(vcpu, VMX_ENTRY_EXCEPTION_ERROR_CODE, error_code);
         }
     }
 
-    if (vector == VECTOR_PF) {
-        vmcs_write(vcpu, VMX_ENTRY_INSTRUCTION_LENGTH, exit_instr_length);
-        vmcs_write(vcpu, VMX_ENTRY_INTERRUPT_INFO, intr_info);
-    } else {
-        vmwrite(vcpu, VMX_ENTRY_INSTRUCTION_LENGTH, exit_instr_length);
-        vmwrite(vcpu, VMX_ENTRY_INTERRUPT_INFO, intr_info);
-    }
+    vmcs_write(vcpu, VMX_ENTRY_INSTRUCTION_LENGTH, exit_instr_length);
+    vmcs_write(vcpu, VMX_ENTRY_INTERRUPT_INFO, intr_info);
 
     hax_debug("Guest is injecting exception info:%x\n", intr_info);
     vcpu->event_injected = 1;

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -126,7 +126,7 @@ uint hax_intr_is_blocked(struct vcpu_t *vcpu)
     if (!(rflags & EFLAGS_IF))
         return 1;
 
-    intr_status = vmx(vcpu, interruptibility_state).raw;
+    intr_status = vmcs_read(vcpu, GUEST_INTERRUPTIBILITY);
     if (intr_status & 3)
         return 1;
     return 0;

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -119,10 +119,11 @@ static void hax_enable_intr_window(struct vcpu_t *vcpu)
  */
 uint hax_intr_is_blocked(struct vcpu_t *vcpu)
 {
-    struct vcpu_state_t *state = vcpu->state;
     uint32_t intr_status;
+    uint64_t rflags;
 
-    if (!(state->_eflags & EFLAGS_IF))
+    rflags = vcpu_get_rflags(vcpu);
+    if (!(rflags & EFLAGS_IF))
         return 1;
 
     intr_status = vmx(vcpu, interruptibility_state).raw;

--- a/core/page_walker.c
+++ b/core/page_walker.c
@@ -569,9 +569,9 @@ uint32_t pw_perform_page_walk(
     uint64_t efer_value = vcpu->state->_efer;
     bool is_nxe = ((efer_value & IA32_EFER_XD) != 0);
     bool is_lme = ((efer_value & IA32_EFER_LME) != 0);
-    uint64_t cr0 = vcpu->state->_cr0;
-    uint64_t cr3 = vcpu->state->_cr3;
-    uint64_t cr4 = vcpu->state->_cr4;
+    uint64_t cr0 = vcpu_get_cr0(vcpu);
+    uint64_t cr3 = vcpu_get_cr3(vcpu);
+    uint64_t cr4 = vcpu_get_cr4(vcpu);
     bool is_wp = ((cr0 & CR0_WP) != 0);
     bool is_pae = ((cr4 & CR4_PAE) != 0);
     bool is_pse = ((cr4 & CR4_PSE) != 0);

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -562,6 +562,7 @@ static void vcpu_init(struct vcpu_t *vcpu)
     vmx(vcpu, cr0_shadow) = 0;
     vmx(vcpu, cr4_mask) = 0;
     vmx(vcpu, cr4_shadow) = 0;
+    vmx(vcpu, parent) = vcpu;
 
     vcpu->ref_count = 1;
 

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -557,7 +557,6 @@ static void vcpu_init(struct vcpu_t *vcpu)
     vcpu->cr_pat = 0x0007040600070406ULL;
     vcpu->cpuid_features_flag_mask = 0xffffffffffffffffULL;
     vcpu->cur_state = GS_VALID;
-    vmx(vcpu, entry_exception_vector) = ~0u;
     vmx(vcpu, cr0_mask) = 0;
     vmx(vcpu, cr0_shadow) = 0;
     vmx(vcpu, cr4_mask) = 0;

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1413,6 +1413,10 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
     vmwrite(vcpu, HOST_GDTR_BASE, get_kernel_gdtr_base());
     vmwrite(vcpu, HOST_IDTR_BASE, get_kernel_idtr_base());
 
+    // The host RIP, used during VM-exit events, is only updated if HAXM
+    // is reloaded. Thus never changes during the lifetime of the VCPU.
+    vmwrite(vcpu, HOST_RIP, (mword)vmx_get_rip());
+
 #define WRITE_CONTROLS(vcpu, f, v) {                                    \
     uint32_t g = v & cpu_data->vmx_info.v##_1 | cpu_data->vmx_info.v##_0; \
     vmwrite(vcpu, f, v = g);                                            \

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -296,3 +296,20 @@ void get_interruption_info_t(interruption_info_t *info, uint8_t v, uint8_t t)
     info->reserved = 0;
     info->valid = 1;
 }
+
+#define COMP_PENDING_0(name)
+#define COMP_PENDING_1(name) \
+    if (vcpu->vmx.vmcs_cache_w.name##_dirty) \
+        vmwrite(vcpu, name, vcpu->vmx.vmcs.name##_value);
+#define COMP_PENDING(cache_r, cache_w, width, name) \
+    COMP_PENDING_##cache_w(name)
+
+void vmcs_write_pending(struct vcpu_t* vcpu)
+{
+    if (!vcpu || !vcpu->vmx.vmcs_cache_w.dirty)
+        return;
+
+#define COMP COMP_PENDING
+    VMCS_COMPS
+#undef COMP
+}

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -327,6 +327,16 @@ void vcpu_vmcs_flush_cache_w(struct vcpu_t *vcpu)
     vcpu->vmx.vmcs_cache_w.dirty = 0;
 }
 
+mword vcpu_get_rflags(struct vcpu_t *vcpu)
+{
+    return vmcs_read(vcpu, GUEST_RFLAGS);
+}
+
+mword vcpu_get_rsp(struct vcpu_t *vcpu)
+{
+    return vmcs_read(vcpu, GUEST_RSP);
+}
+
 mword vcpu_get_rip(struct vcpu_t *vcpu)
 {
     return vmcs_read(vcpu, GUEST_RIP);

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -326,3 +326,127 @@ void vcpu_vmcs_flush_cache_w(struct vcpu_t *vcpu)
     }
     vcpu->vmx.vmcs_cache_w.dirty = 0;
 }
+
+uint16_t vcpu_get_seg_selector(struct vcpu_t *vcpu, int seg)
+{
+    uint16_t value;
+
+    switch (seg) {
+    case SEG_CS:
+        value = vmcs_read(vcpu, GUEST_CS_SELECTOR);
+        break;
+    case SEG_SS:
+        value = vmcs_read(vcpu, GUEST_SS_SELECTOR);
+        break;
+    case SEG_DS:
+        value = vmcs_read(vcpu, GUEST_DS_SELECTOR);
+        break;
+    case SEG_ES:
+        value = vmcs_read(vcpu, GUEST_ES_SELECTOR);
+        break;
+    case SEG_FS:
+        value = vmcs_read(vcpu, GUEST_FS_SELECTOR);
+        break;
+    case SEG_GS:
+        value = vmcs_read(vcpu, GUEST_GS_SELECTOR);
+        break;
+    default:
+        hax_error("vcpu_get_seg_selector: Unexpected segment (%d)\n", seg);
+        value = 0;
+    }
+    return value;
+}
+
+mword vcpu_get_seg_base(struct vcpu_t *vcpu, int seg)
+{
+    mword value;
+
+    switch (seg) {
+    case SEG_CS:
+        value = vmcs_read(vcpu, GUEST_CS_BASE);
+        break;
+    case SEG_SS:
+        value = vmcs_read(vcpu, GUEST_SS_BASE);
+        break;
+    case SEG_DS:
+        value = vmcs_read(vcpu, GUEST_DS_BASE);
+        break;
+    case SEG_ES:
+        value = vmcs_read(vcpu, GUEST_ES_BASE);
+        break;
+    case SEG_FS:
+        value = vmcs_read(vcpu, GUEST_FS_BASE);
+        break;
+    case SEG_GS:
+        value = vmcs_read(vcpu, GUEST_GS_BASE);
+        break;
+    default:
+        hax_error("vcpu_get_seg_base: Unexpected segment (%d)\n", seg);
+        value = 0;
+    }
+    return value;
+}
+
+uint32_t vcpu_get_seg_limit(struct vcpu_t *vcpu, int seg)
+{
+    uint32_t value;
+
+    switch (seg) {
+    case SEG_CS:
+        value = vmcs_read(vcpu, GUEST_CS_LIMIT);
+        break;
+    case SEG_SS:
+        value = vmcs_read(vcpu, GUEST_SS_LIMIT);
+        break;
+    case SEG_DS:
+        value = vmcs_read(vcpu, GUEST_DS_LIMIT);
+        break;
+    case SEG_ES:
+        value = vmcs_read(vcpu, GUEST_ES_LIMIT);
+        break;
+    case SEG_FS:
+        value = vmcs_read(vcpu, GUEST_FS_LIMIT);
+        break;
+    case SEG_GS:
+        value = vmcs_read(vcpu, GUEST_GS_LIMIT);
+        break;
+    default:
+        hax_error("vcpu_get_seg_limit: Unexpected segment (%d)\n", seg);
+        value = 0;
+    }
+    return value;
+}
+
+uint32_t vcpu_get_seg_ar(struct vcpu_t *vcpu, int seg)
+{
+    uint32_t value;
+
+    switch (seg) {
+    case SEG_CS:
+        value = vmcs_read(vcpu, GUEST_CS_AR);
+        break;
+    case SEG_SS:
+        value = vmcs_read(vcpu, GUEST_SS_AR);
+        break;
+    case SEG_DS:
+        value = vmcs_read(vcpu, GUEST_DS_AR);
+        break;
+    case SEG_ES:
+        value = vmcs_read(vcpu, GUEST_ES_AR);
+        break;
+    case SEG_FS:
+        value = vmcs_read(vcpu, GUEST_FS_AR);
+        break;
+    case SEG_GS:
+        value = vmcs_read(vcpu, GUEST_GS_AR);
+        break;
+    default:
+        hax_error("vcpu_get_seg_ar: Unexpected segment (%d)\n", seg);
+        value = 0;
+    }
+
+    if (value & (1 << 16) /* ar.null */) {
+        return 0;
+    }
+    return value;
+}

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -327,6 +327,11 @@ void vcpu_vmcs_flush_cache_w(struct vcpu_t *vcpu)
     vcpu->vmx.vmcs_cache_w.dirty = 0;
 }
 
+mword vcpu_get_rip(struct vcpu_t *vcpu)
+{
+    return vmcs_read(vcpu, GUEST_RIP);
+}
+
 uint16_t vcpu_get_seg_selector(struct vcpu_t *vcpu, int seg)
 {
     uint16_t value;

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -781,7 +781,7 @@ retry:
 
 bool handle_vtlb(struct vcpu_t *vcpu)
 {
-    uint32_t access = vmx(vcpu, exit_exception_error_code);
+    uint32_t access = vmcs_read(vcpu, VM_EXIT_INFO_EXCEPTION_ERROR_CODE);
     pagemode_t mode = vcpu_get_pagemode(vcpu);
     hax_paddr_t pdir = vcpu->state->_cr3 & (mode == PM_PAE ? ~0x1fULL : ~0xfffULL);
     hax_vaddr_t cr2 = vmx(vcpu, exit_qualification).address;

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -1162,10 +1162,13 @@ uint vcpu_translate(struct vcpu_t *vcpu, hax_vaddr_t va, uint access, hax_paddr_
 
 pagemode_t vcpu_get_pagemode(struct vcpu_t *vcpu)
 {
-    if (!(vcpu->state->_cr0 & CR0_PG))
+    uint64_t cr0 = vcpu_get_cr0(vcpu);
+    uint64_t cr4 = vcpu_get_cr4(vcpu);
+
+    if (!(cr0 & CR0_PG))
         return PM_FLAT;
 
-    if (!(vcpu->state->_cr4 & CR4_PAE))
+    if (!(cr4 & CR4_PAE))
         return PM_2LVL;
 
     // Only support pure 32-bit paging. May support PAE paging in future.

--- a/core/vtlb.c
+++ b/core/vtlb.c
@@ -779,12 +779,12 @@ retry:
     return TF_OK;
 }
 
-bool handle_vtlb(struct vcpu_t *vcpu)
+bool handle_vtlb(struct vcpu_t *vcpu, hax_vaddr_t addr)
 {
     uint32_t access = vmcs_read(vcpu, VM_EXIT_INFO_EXCEPTION_ERROR_CODE);
     pagemode_t mode = vcpu_get_pagemode(vcpu);
     hax_paddr_t pdir = vcpu->state->_cr3 & (mode == PM_PAE ? ~0x1fULL : ~0xfffULL);
-    hax_vaddr_t cr2 = vmx(vcpu, exit_qualification).address;
+    hax_vaddr_t cr2 = addr;
 
     uint32_t ret = vtlb_handle_page_fault(vcpu, mode, pdir, cr2, access);
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -497,20 +497,6 @@ TODO: Describe
 * Since: API v1
 * Parameter: `struct vcpu_state_t regs`, where
   ```
-  union interruptibility_state_t {
-      uint32 raw;
-      struct {
-          uint32 sti_blocking   : 1;
-          uint32 movss_blocking : 1;
-          uint32 smi_blocking   : 1;
-          uint32 nmi_blocking   : 1;
-          uint32 reserved       : 28;
-      };
-      uint64_t pad;
-  };
-  
-  typedef union interruptibility_state_t interruptibility_state_t;
-  
   struct segment_desc_t {
       uint16 selector;
       uint16 _dummy;
@@ -652,7 +638,7 @@ TODO: Describe
   
       uint32 _activity_state;
       uint32 pad;
-      interruptibility_state_t _interruptibility_state;
+      uint64 pad2;
   };
   ```
   * (Input) `regs`:

--- a/include/vcpu_state.h
+++ b/include/vcpu_state.h
@@ -31,20 +31,6 @@
 #ifndef HAX_VCPU_STATE_H_
 #define HAX_VCPU_STATE_H_
 
-union interruptibility_state_t {
-    uint32_t raw;
-    struct {
-        uint32_t sti_blocking   : 1;
-        uint32_t movss_blocking : 1;
-        uint32_t smi_blocking   : 1;
-        uint32_t nmi_blocking   : 1;
-        uint32_t reserved       : 28;
-    };
-    uint64_t pad;
-} PACKED;
-
-typedef union interruptibility_state_t interruptibility_state_t;
-
 // Segment descriptor
 struct segment_desc_t {
     uint16_t selector;
@@ -187,7 +173,6 @@ struct vcpu_state_t {
 
     uint32_t _activity_state;
     uint32_t pad;
-    interruptibility_state_t _interruptibility_state;
 } PACKED;
 
 void dump(void);

--- a/include/vcpu_state.h
+++ b/include/vcpu_state.h
@@ -173,6 +173,7 @@ struct vcpu_state_t {
 
     uint32_t _activity_state;
     uint32_t pad;
+    uint64_t pad2;
 } PACKED;
 
 void dump(void);


### PR DESCRIPTION
**Disclaimer: This patch isn't finished, but it's available for early reviews/discussion.**

## Motivation

During development, running HAXM in a virtual machine prevents your "bare-metal" host system from kernel panics if runtime errors occur. The downside of nested virtualization, is that during L2-guest VM-exit events, the L1-hypervisor, i.e. HAXM, might need to perform actions, e.g. vmread/vmwrite, that trigger another exit to the L0-hypervisor, i.e. KVM, VMware, etc. These recursive exits add latency so it's convenient to minimize them.

While booting few kernels using both HAXM and KVM as L1-hypervisor, under the same conditions, HAXM appears to be 4-5 times slower than KVM (related: #40). After measuring the amount of vmread/vmwrite's between guest-exit and guest-enter events, I've noticed HAXM amount is (unsurprisingly) 4-5 times higher. Specifically:

- **KVM**: Does 6-10 reads and 2-6 writes on average.
  ~**KVM**: Does 4-8 reads and 0-4 writes on average (depends on VMX exit handler).~
  
- **HAXM**: Does 32-33 reads and 21-23 writes on average.
  ~**HAXM**: Does 32 reads and 1 write (nearly always!).~


Here's the raw data, corresponds to around the first few seconds of trying to boot a Windows 7 install disc: [vmx-measurements.zip](https://github.com/intel/haxm/files/2600897/vmx-measurements.zip) ~([haxm-vmx.log](https://github.com/intel/haxm/files/2592959/haxm-vmx.log) and [kvm-vmx.log](https://github.com/intel/haxm/files/2592961/kvm-vmx.log))~. Efforts at 96af3d28 (thanks @junxiaoc!) have improved this situation, but there's still room for improvement.

## Changes

Previous efforts, and other hypervisors like KVM, have minimized vmread/vmwrite usage by caching the component values with hand-written helper functions. While this *works*, it doesn't scale well for the 120+ components. Plus, it's not trivial what should be cached: caching unused components is counterproductive. Fine-tuning the set of cached components when in manually-implemented code is too time-consuming.

Instead, this patch relies in preprocessor [X-Macros](https://en.wikipedia.org/wiki/X_Macro) to **automatically** create the cache structures, alongside cached/dirty flags and helper functions to access **all** VMCS components. This [Godbolt snippet](https://godbolt.org/z/_3tuHb) allows to inspect the preprocessor output for clear view of the resulting code (ideally, apply [clang-format](https://zed0.co.uk/clang-format-configurator/)).

Summarizing the changes, this patch:
- Moves some VMX-specific definitions to *vmx.h* (required by other changes).
- Adds VMCS-cache macros to *vmx.h*.
- Optimizes code by using new VMCS-cache macros: Removed most _vmcs_pending*_ fields and unnecessary *vmread*'s at the end of `cpu_vmx_execute`.

## Benchmarks

Measuring time elapsed between booting a virtual machine with a Windows XP SP2 installation disc, until the installer shows the "welcome screen", using an Ubuntu 18.04 (+ Linux 4.17) host. This is a particularly bad scenario that shows up to x10 slowdown. (Disclaimer: time measured manually with my phone).

- **KVM**: 45.4 seconds.
- **HAXM (before)**: 532.5 seconds.
- **HAXM (after)**: *TODO*.

## Pending

- [ ] Using VMCS-cache for VCPU state reads/writes (huge performance impact!).
- [ ] Replacing remaining vmread/vmwrite's.
