### PR TITLE
Added tests and 32-bit targets to haxm-windows Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ matrix:
       os: windows
       install:
         - choco install -y nuget.commandline
-        - choco install -y windowsdriverkit10
+        - choco install -y windowsdriverkit10 --version 10.0.17763
+        - choco install -y windows-sdk-10.1 --version 10.1.17763.1
       script:
         - cd platforms/windows
         - nuget restore
@@ -44,4 +45,7 @@ matrix:
         #       but since those are not supported by TravisCI, we need to install targets manually.
         - unzip "/c/Program Files (x86)/Windows Kits/10/Vsix/WDK.vsix" -d wdk
         - cp -R wdk/\$VCTargets/* "$MSVC/Common7/IDE/VC/VCTargets"
-        - MSBuild.exe haxm-windows.vcxproj //p:Configuration="Debug" //p:Platform="x64"
+        - export PROPS="//p:DefaultWindowsSDKVersion=10.0.17763.0 //p:SpectreMitigation=false"
+        - MSBuild.exe haxm.sln $PROPS //p:Configuration="Debug" //p:Platform="Win32"
+        - MSBuild.exe haxm.sln $PROPS //p:Configuration="Debug" //p:Platform="x64"
+        - build/tests/x64/haxm-tests.exe


### PR DESCRIPTION
Previously, we couldn't build *haxm-tests.vcxproj* on TravisCI as it depends on the Windows SDK and:
- Windows SDK 8/8.1 required the Universal CRT to be separately installed for which no Chocolatey package is available (as of today). This is solved in Windows SDK 10.x as it's already included.
- Windows SDK 10.0.17134.12 and earlier [failed](https://github.com/intel/haxm/pull/123#issuecomment-438898613) under Windows Server 2016 (v1803) which is used by TravisCI VMs. This is solved in v10.0.17763.1, which wasn't available at the time.

The bug was filed to the maintainers of the Windows SDK and WDK (since they need to be synchronized) packages, and both offer now the version 10.0.17763.1 (v1809). Further details are available at:
- `windows-sdk-10.1`: https://chocolatey.org/packages/windows-sdk-10.1#comment-4196624327
- `windowsdriverkit10`: https://chocolatey.org/packages/windowsdriverkit10#comment-4201628042

Now the **complete** solution is built, both for 32-bit and 64-bit targets (on *Debug* mode), and [tests are run](https://travis-ci.com/intel/haxm/jobs/159783285#L813). This solves the request at https://github.com/intel/haxm/pull/123#issuecomment-438893054. I'm afraid 32-bit Linux builds might be too complex for now (not sure how to cross-compile drivers). We can leave this and parallelizing builds for future PRs. Either way, it's safe too assume that any 32-bit specific bugs will be caught by the 32-bit Windows builds.

Additionally, I have pinned the versions of both packages to prevent breaking the builds if they get updated again, see https://github.com/intel/haxm/pull/129#issuecomment-440279305 and https://github.com/intel/haxm/pull/126#issuecomment-440217159 (among others).

Signed-off-by: Alexandro Sanchez Bach <asanchez@kryptoslogic.com>