### PR TITLE
Generate tests in configuration subfolder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ matrix:
         - export PROPS="//p:DefaultWindowsSDKVersion=10.0.17763.0 //p:SpectreMitigation=false"
         - MSBuild.exe haxm.sln $PROPS //p:Configuration="Debug" //p:Platform="Win32"
         - MSBuild.exe haxm.sln $PROPS //p:Configuration="Debug" //p:Platform="x64"
-        - build/tests/x64/haxm-tests.exe
+        - build/tests/x64/Debug/haxm-tests.exe

--- a/platforms/windows/haxm-core.vcxproj
+++ b/platforms/windows/haxm-core.vcxproj
@@ -70,8 +70,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Label="Configuration">
-    <OutDir>$(SolutionDir)build\core\$(Platform)\$(ConfigurationName)\</OutDir>
-    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(ConfigurationName)\</IntDir>
+    <OutDir>$(SolutionDir)build\core\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <!-- The WrappedTaskItems label is used by the conversion tool to identify the location where items 
         associated with wrapped tasks will reside.-->

--- a/platforms/windows/haxm-tests.vcxproj
+++ b/platforms/windows/haxm-tests.vcxproj
@@ -36,8 +36,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <PropertyGroup Label="Configuration">
-    <OutDir>$(SolutionDir)build\tests\$(Platform)\$(ConfigurationName)\</OutDir>
-    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(ConfigurationName)\</IntDir>
+    <OutDir>$(SolutionDir)build\tests\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tests\test_emulator.cpp" />

--- a/platforms/windows/haxm-windows.vcxproj
+++ b/platforms/windows/haxm-windows.vcxproj
@@ -72,12 +72,12 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Label="Configuration">
-    <OutDir>$(SolutionDir)build\out\$(Platform)\$(ConfigurationName)\</OutDir>
-    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(ConfigurationName)\</IntDir>
+    <OutDir>$(SolutionDir)build\out\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\intermediates\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>$(SolutionDir)build\core\$(Platform)\$(ConfigurationName)\haxlib.lib;$(DDK_LIB_PATH)wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)build\core\$(Platform)\$(Configuration)\haxlib.lib;$(DDK_LIB_PATH)wdmsec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
       <SDLCheck>true</SDLCheck>


### PR DESCRIPTION
Fixes issue reported at https://github.com/intel/haxm/pull/133#discussion_r235237002.

Somehow, I had specified `$(ConfigurationName)` rather than `$(Configuration)` in the intermediates/output path. This worked fine for *haxm-core.vcxproj* and *haxm-windows.vcxproj*, but not for *haxm-tests.vcxproj*.

Signed-off-by: Alexandro Sanchez Bach <asanchez@kryptoslogic.com>