### PR TITLE
Fixed PAE issues

### DIFF
--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -200,7 +200,8 @@ struct vcpu_t {
         uint64_t fs_base_dirty                   : 1;
         uint64_t interruptibility_dirty          : 1;
         uint64_t pcpu_ctls_dirty                 : 1;
-        uint64_t padding                         : 46;
+        uint64_t pae_pdpt_dirty                  : 1;
+        uint64_t padding                         : 45;
     };
 
     /* For TSC offseting feature*/


### PR DESCRIPTION
Fixed two bugs
1) PDPTEs were written to vmcs even when they were not read after the last vmexit. Since CR3 writes are not intercepted, it is possible that the guest in PAE mode changes CR3, the processor changes PDPTE values and this change doesn't update cached pae_pdpte array values. At the next cr0\cr4 write when is_ept_pae in exit_cr_access is false, new PDPTE values are not read, and old ones are written to PDPTEs in vmcs. This leads to guest crash at the next instruction. Intercepting CR3 writes is too a feasible solution, but with a performance penalty due to many additional vmexits.
2) CR3 in PAE mode is 32-byte aligned, pw_perform_page_walk passed to gpa_space_map_page the page (pdpt_gpa >> PG_ORDER_4K) and got hva of the page were CR3 points, not the hva of gpa in CR3. Fixed by calculating the offset of CR3 value from its page start and adding it to the page hva. This fix is only in the CONFIG_HAX_EPT2 branch and was tested only in pure PAE mode, not in LME (the modified code affects this branch too).

Both fixes were compiled only for Windows and were tested on a Win10 x64 host and Win7 x32 guest. I was able to run the guest, so this fix maybe fixes #118.
