### PR TITLE
windows: Fix garbled text in version information

### DIFF
--- a/platforms/windows/version.rc
+++ b/platforms/windows/version.rc
@@ -43,8 +43,8 @@
 #define VER_COMPANYNAME_STR         "Intel  Corporation"
 #define VER_PRODUCTNAME_STR         "HAXM"
 #define VER_LEGALCOPYRIGHT_YEARS    "2013"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright© " VER_LEGALCOPYRIGHT_YEARS " Intel Corporation"
-#define VER_LEGALTRADEMARKS_STR     "Copyright© 2013 Intel Corporation"
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) " VER_LEGALCOPYRIGHT_YEARS " Intel Corporation"
+#define VER_LEGALTRADEMARKS_STR     VER_LEGALCOPYRIGHT_STR
 
 #define VER_PRODUCTVERSION          HAXM_RELEASE_VERSION
 #define VER_PRODUCTVERSION_STR      HAXM_RELEASE_VERSION_STR


### PR DESCRIPTION
Since commit 592f97a, which touched version.rc, the version
information compiled into the Windows driver binary (IntelHaxm.sys)
has had an encoding issue, where the copyright symbol is replaced
by a question mark. To work around the issue, avoid any Unicode
character in version.rc, and use "(c)" for the copyright symbol.

+ Avoid defining the same string twice for two version information
  fields.

Signed-off-by: Yu Ning <yu.ning@intel.com>