### PR TITLE
Include hax_types in core/include/config.h

### DIFF
--- a/core/include/config.h
+++ b/core/include/config.h
@@ -31,6 +31,8 @@
 #ifndef HAX_CORE_CONFIG_H_
 #define HAX_CORE_CONFIG_H_
 
+#include "../../include/hax_types.h"
+
 struct config_t {
     int memory_pass_through;
     int disable_ept;


### PR DESCRIPTION
This allows to the get correct reference of PLATFORM_NETBSD regardless
of include order from other part of the codebase.

Signed-off-by: Kamil Rytarowski <n54@gmx.com>