### PR TITLE
Mark the NetBSD driver multiprocessor safe

### DIFF
--- a/platforms/netbsd/hax_entry_hax.c
+++ b/platforms/netbsd/hax_entry_hax.c
@@ -60,7 +60,7 @@ struct cdevsw hax_cdevsw = {
     .d_mmap = nommap,
     .d_kqfilter = nokqfilter,
     .d_discard = nodiscard,
-    .d_flag = D_OTHER
+    .d_flag = D_OTHER | D_MPSAFE
 };
 
 int hax_open(dev_t dev __unused, int flags __unused, int mode __unused,

--- a/platforms/netbsd/hax_entry_vcpu.c
+++ b/platforms/netbsd/hax_entry_vcpu.c
@@ -55,7 +55,7 @@ struct cdevsw hax_vcpu_cdevsw = {
     .d_mmap = nommap,
     .d_kqfilter = nokqfilter,
     .d_discard = nodiscard,
-    .d_flag = D_OTHER
+    .d_flag = D_OTHER | D_MPSAFE
 };
 
 /* VCPU operations */

--- a/platforms/netbsd/hax_entry_vm.c
+++ b/platforms/netbsd/hax_entry_vm.c
@@ -55,7 +55,7 @@ struct cdevsw hax_vm_cdevsw = {
     .d_mmap = nommap,
     .d_kqfilter = nokqfilter,
     .d_discard = nodiscard,
-    .d_flag = D_OTHER
+    .d_flag = D_OTHER | D_MPSAFE
 };
 
 int hax_vm_open(dev_t self, int flag __unused, int mode __unused,


### PR DESCRIPTION
This allows to use guest machines with more than a single vcpu without
drastic performance hit.

Signed-off-by: Kamil Rytarowski <n54@gmx.com>