### PR TITLE
Revamp README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # Intel Hardware Accelerated Execution Manager (HAXM)
-[HAXM][intel-haxm] is a hardware-assisted virtualization engine (hypervisor)
-that uses [Intel Virtualization Technology][intel-vt] to speed up IA (x86/
-x86\_64) emulation on a host machine running Windows or macOS.
-It started as an [Android SDK][android-studio] component, but has recently
-transformed itself into a general accelerator for [QEMU][qemu].
+HAXM is a cross-platform hardware-assisted virtualization engine (hypervisor),
+widely used as an accelerator for [Android Emulator][android-studio] and
+[QEMU][qemu]. It has always supported running on Windows and macOS, and has been
+ported to other host operating systems as well, such as Linux and NetBSD.
 
-HAXM can be built as either a kernel-mode driver for Windows or a kernel
-extension (_kext_) for macOS. If you are interested in building HAXM from the
-source code, please read on. If you are just looking for the latest HAXM
-release, you can get it [here][github-haxm-latest-release].
+HAXM runs as a kernel-mode driver on the host operating system, and provides a
+KVM-like interface to user space, thereby enabling applications like QEMU to
+utilize the hardware virtualization capabilities built into modern Intel CPUs,
+namely [Intel Virtualization Technology][intel-vt].
 
-## Usage
+## Downloads
+The latest HAXM release for Windows and macOS hosts are available
+[here][github-haxm-latest-release].
 
+## Contributing
 Detailed instructions for building and testing HAXM can be found at:
 * [Manual for Linux](docs/manual-linux.md)
 * [Manual for macOS](docs/manual-macos.md)
 * [Manual for Windows](docs/manual-windows.md)
 
+If you would like to contribute a patch to the code base, please also read
+[these guidelines](CONTRIBUTING.md).
+
 ## Reporting an Issue
-You are welcome to file a GitHub issue if you discover a general HAXM bug or
-have a feature request.
+You are welcome to file a [GitHub issue][github-haxm-issues] if you discover a
+general HAXM bug or have a feature request.
 
 However, please do not use the GitHub issue tracker to report security
 vulnerabilities. If you have information about a security issue or vulnerability
@@ -32,9 +37,9 @@ This project has adopted the Contributor Covenant, in the hope of building a
 welcoming and inclusive community. All participants in the project should adhere
 to this [code of conduct](CODE_OF_CONDUCT.md).
 
-[intel-haxm]: https://software.intel.com/en-us/android/articles/intel-hardware-accelerated-execution-manager
 [intel-vt]: https://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
 [android-studio]: https://developer.android.com/studio/index.html
 [qemu]: https://www.qemu.org/
 [github-haxm-latest-release]: https://github.com/intel/haxm/releases/latest
+[github-haxm-issues]: https://github.com/intel/haxm/issues
 [intel-security-email]: mailto:secure@intel.com


### PR DESCRIPTION
Remove the link to the old HAXM website on intel.com, because we
want people to come to GitHub to download HAXM or report issues.

In addition, take the chance to revamp the README document, which
is slightly outdated.

@hyuan3 and @wayne-ma have also contributed to the new content.

Signed-off-by: Yu Ning <yu.ning@intel.com>