### PR TITLE
Fix FPU DNA exception on NetBSD

### DIFF
--- a/core/ia32.c
+++ b/core/ia32.c
@@ -81,6 +81,11 @@ uint64_t ia32_rdtsc(void)
 #endif
 }
 
+void hax_clts(void)
+{
+    asm_clts();
+}
+
 void hax_fxinit(void)
 {
     asm_fxinit();

--- a/core/ia32_ops.asm
+++ b/core/ia32_ops.asm
@@ -213,6 +213,10 @@ function asm_enable_irq, 0
     sti
     ret
 
+function asm_clts, 0
+    clts
+    ret
+
 function asm_fxinit, 0
     finit
     ret

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -84,6 +84,8 @@ struct hstate {
     uint64_t dr3;
     uint64_t dr6;
     uint64_t dr7;
+    // CR0
+    bool cr0_ts;
 };
 
 struct hstate_compare {

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -72,6 +72,7 @@ void ASMCALL set_kernel_fs(uint16_t val);
 
 void ASMCALL asm_btr(uint8_t *addr, uint bit);
 void ASMCALL asm_bts(uint8_t *addr, uint bit);
+void ASMCALL asm_clts(void);
 void ASMCALL asm_fxinit(void);
 void ASMCALL asm_fxsave(mword *addr);
 void ASMCALL asm_fxrstor(mword *addr);
@@ -84,6 +85,8 @@ uint64_t ia32_rdmsr(uint32_t reg);
 void ia32_wrmsr(uint32_t reg, uint64_t val);
 
 uint64_t ia32_rdtsc(void);
+
+void hax_clts(void);
 
 void hax_fxinit(void);
 void hax_fxsave(mword *addr);


### PR DESCRIPTION
Call clts (Clear Task-Switch) bit before calling FPU functions.
This prevents FPU Device Not Available exceptions.

Store the original CR0_TS of host before entering FPU state and
restore it on FPU exit.

Closes #166