### PR TITLE
[netbsd] Correct retrieving the CPU index

### DIFF
--- a/platforms/netbsd/hax_entry.c
+++ b/platforms/netbsd/hax_entry.c
@@ -33,6 +33,7 @@
 #include <sys/conf.h>
 #include <sys/device.h>
 #include <sys/module.h>
+#include <sys/cpu.h>
 
 #include "../../core/include/config.h"
 #include "../../core/include/hax_core_interface.h"
@@ -230,7 +231,7 @@ haxm_modcmd(modcmd_t cmd, void *arg __unused)
         for (CPU_INFO_FOREACH(cii, ci)) {
             ++max_cpus;
             if (!ISSET(ci->ci_schedstate.spc_flags, SPCF_OFFLINE)) {
-                cpu_online_map |= __BIT(ci->ci_cpuid);
+                cpu_online_map |= __BIT(cpu_index(ci));
             }
         }
 

--- a/platforms/netbsd/hax_wrapper.c
+++ b/platforms/netbsd/hax_wrapper.c
@@ -35,6 +35,7 @@
 #include <sys/mutex.h>
 #include <sys/systm.h>
 #include <sys/xcall.h>
+#include <sys/cpu.h>
 #include <machine/cpu.h>
 #include <machine/cpufunc.h>
 
@@ -61,7 +62,7 @@ int hax_log_level(int level, const char *fmt,  ...)
 
 uint32_t hax_cpuid(void)
 {
-    return curcpu()->ci_cpuid;
+    return cpu_index(curcpu());
 }
 
 typedef struct smp_call_parameter {


### PR DESCRIPTION
curcpu()->ci_cpuid is not guaranteed to return incremental indices 0..N-1.

This caused crashes on some NetBSD machines.

Patch and report by Andreas Gustafsson (NetBSD).

Signed-off-by: Kamil Rytarowski <n54@gmx.com>