### PR TITLE
Use Travis CI's default macOS build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ matrix:
   include:
     - name: "haxm-darwin"
       os: osx
-      osx_image: xcode10
       addons:
         homebrew:
           packages:
             - nasm
       script:
         - cd platforms/darwin
-        - xcodebuild -configuration Debug -sdk macosx10.14
+        - xcodebuild -configuration Debug -sdk macosx
 
     - name: "haxm-linux"
       os: linux


### PR DESCRIPTION
The haxm-darwin Travis build has been failing due to a git/Homebrew
error:

 Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
 fatal: unknown value for config 'protocol.version': 2

Work around this issue by switching to Travis CI's default osx_image
setting:

https://docs.travis-ci.com/user/reference/osx/#macos-version

Currently, the default osx_image is xcode9.4, which supports macOS
SDK up to 10.13. Change the HAXM build command to use the latest
macOS SDK available.

Signed-off-by: Yu Ning <yu.ning@intel.com>