### PR TITLE
 Added support for PUSH/POP instructions

### DIFF
--- a/core/emulate.c
+++ b/core/emulate.c
@@ -1182,13 +1182,6 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
     }
 
     /* Apply flags */
-    if (flags & INSN_BYTEOP) {
-        ctxt->operand_size = 1;
-    }
-    if (flags & INSN_STACK) {
-        if (ctxt->operand_size == 4 && ctxt->mode == EM_MODE_PROT64)
-            ctxt->operand_size = 8;
-    }
     if (flags & INSN_GROUP) {
         const struct em_opcode_t *group_opcode;
 
@@ -1199,6 +1192,7 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
         group_opcode = &opcode->group[ctxt->modrm.opc];
         opcode->handler = group_opcode->handler;
         opcode->flags |= group_opcode->flags;
+        flags = opcode->flags;
         if (group_opcode->decode_dst != decode_op_none) {
             opcode->decode_dst = group_opcode->decode_dst;
         }
@@ -1208,6 +1202,13 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
         if (group_opcode->decode_src2 != decode_op_none) {
             opcode->decode_src2 = group_opcode->decode_src2;
         }
+    }
+    if (flags & INSN_BYTEOP) {
+        ctxt->operand_size = 1;
+    }
+    if (flags & INSN_STACK) {
+        if (ctxt->operand_size == 4 && ctxt->mode == EM_MODE_PROT64)
+            ctxt->operand_size = 8;
     }
 
     /* Some unimplemented opcodes have an all-zero em_opcode_t */

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -100,10 +100,8 @@ struct em_operand_t;
 #define EM_OPS_NO_TRANSLATION  (1 << 0)
 
 typedef struct em_vcpu_ops_t {
-    uint64_t (*read_gpr)(void *vcpu, uint32_t reg_index,
-                         uint32_t size);
-    void (*write_gpr)(void *vcpu, uint32_t reg_index,
-                      uint64_t value, uint32_t size);
+    uint64_t (*read_gpr)(void *vcpu, uint32_t reg_index);
+    void (*write_gpr)(void *vcpu, uint32_t reg_index, uint64_t value);
     uint64_t (*read_rflags)(void *vcpu);
     void (*write_rflags)(void *vcpu, uint64_t value);
     uint64_t (*get_segment_base)(void *vcpu, uint32_t segment);
@@ -170,6 +168,11 @@ typedef struct em_context_t {
     struct em_operand_t src1;
     struct em_operand_t src2;
     uint64_t rflags;
+
+    /* Cache */
+    uint64_t gpr_cache[16];
+    uint16_t gpr_cache_r;
+    uint16_t gpr_cache_w;
 
     /* Decoder */
     struct {

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -140,6 +140,7 @@ typedef struct em_operand_t {
         } mem;
         struct operand_reg_t {
             uint32_t index;
+            uint32_t shift;
         } reg;
     };
     uint64_t value;

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -175,6 +175,7 @@ typedef struct em_context_t {
     uint16_t gpr_cache_w;
 
     /* Decoder */
+    uint8_t b;
     struct {
         uint8_t prefix;
         union {

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -2182,27 +2182,24 @@ static int vcpu_emulate_insn(struct vcpu_t *vcpu)
     return HAX_EXIT;
 }
 
-static uint64_t vcpu_read_gpr(void *obj, uint32_t reg_index, uint32_t size)
+static uint64_t vcpu_read_gpr(void *obj, uint32_t reg_index)
 {
     struct vcpu_t *vcpu = obj;
     if (reg_index >= 16) {
         hax_panic_vcpu(vcpu, "vcpu_read_gpr: Invalid register index\n");
         return 0;
     }
-    uint64_t value = 0;
-    memcpy(&value, &vcpu->state->_regs[reg_index], size);
-    return value;
+    return vcpu->state->_regs[reg_index];
 }
 
-static void vcpu_write_gpr(void *obj, uint32_t reg_index, uint64_t value,
-                           uint32_t size)
+static void vcpu_write_gpr(void *obj, uint32_t reg_index, uint64_t value)
 {
     struct vcpu_t *vcpu = obj;
     if (reg_index >= 16) {
         hax_panic_vcpu(vcpu, "vcpu_write_gpr: Invalid register index\n");
         return;
     }
-    memcpy(&vcpu->state->_regs[reg_index], &value, size);
+    vcpu->state->_regs[reg_index] = value;
 }
 
 uint64_t vcpu_read_rflags(void *obj)

--- a/tests/test_emulator.cpp
+++ b/tests/test_emulator.cpp
@@ -55,23 +55,20 @@ struct test_cpu_t {
     uint8_t mem[0x100];
 };
 
-uint64_t test_read_gpr(void* obj, uint32_t reg_index, uint32_t size) {
+uint64_t test_read_gpr(void* obj, uint32_t reg_index) {
     test_cpu_t* vcpu = reinterpret_cast<test_cpu_t*>(obj);
     if (reg_index >= 16) {
         throw std::exception("Register index OOB");
     }
-    uint64_t value = 0;
-    memcpy(&value, &vcpu->gpr[reg_index], size);
-    return value;
+    return vcpu->gpr[reg_index];
 }
 
-void test_write_gpr(void* obj, uint32_t reg_index,
-                    uint64_t value, uint32_t size) {
+void test_write_gpr(void* obj, uint32_t reg_index, uint64_t value) {
     test_cpu_t* vcpu = reinterpret_cast<test_cpu_t*>(obj);
     if (reg_index >= 16) {
         throw std::exception("Register index OOB");
     }
-    memcpy(&vcpu->gpr[reg_index], &value, size);
+    vcpu->gpr[reg_index] = value;
 }
 
 uint64_t test_read_rflags(void* obj) {

--- a/tests/test_emulator.cpp
+++ b/tests/test_emulator.cpp
@@ -288,8 +288,8 @@ protected:
 
         // Verify RFLAGS
         if (vcpu_obtained.flags != vcpu_expected.flags)
-            std::cerr << "Flags mismatch on: " << insn << "\n" \
-                << "vcpu_obtained.flags: 0x" << PRINT_U64(vcpu_obtained.flags) << "\n" \
+            std::cerr << "Flags mismatch on: " << insn << "\n"
+                << "vcpu_obtained.flags: 0x" << PRINT_U64(vcpu_obtained.flags) << "\n"
                 << "vcpu_expected.flags: 0x" << PRINT_U64(vcpu_expected.flags) << "\n";
 
 #undef PRINT_U64
@@ -887,6 +887,19 @@ TEST_F(EmulatorTest, insn_cmps) {
     vcpu_expected.gpr[REG_RCX] = 0x1;
     vcpu_expected.flags = RFLAGS_PF;
     run("repe cmpsb", vcpu_original, vcpu_expected);
+}
+
+TEST_F(EmulatorTest, insn_mov) {
+    test_cpu_t vcpu_original;
+    test_cpu_t vcpu_expected;
+
+    // Test: mov r8, r/m8
+    vcpu_original = {};
+    vcpu_original.gpr[REG_RDX] = 0x88;
+    vcpu_original.mem[0x88] = 0x44;
+    vcpu_expected = vcpu_original;
+    vcpu_expected.gpr[REG_RCX] = 0x4400;
+    run("mov ch, [rdx]", vcpu_original, vcpu_expected);
 }
 
 TEST_F(EmulatorTest, insn_movs) {


### PR DESCRIPTION
This pull request fixes #182 (ping @krytarowski) and includes several changes:

## Changes

### Added a register cache to the instruction emulator (c799252)

This implements a cache for reading/writing GPRs in the instruction emulator: Register reads will be stored in ctxt->gpr_cache, and writes will be stored in ctxt->gpr_cache until they are explicitly flushed by `gpr_cache_flush` so that the actual register access, as defined in `em_vcpu_ops_t`, is performed.

Aside from minor performance gains, this change will make easier to introduce instructions with "side effects", e.g. push/pop modifying the stack pointer. The reason is that due to our model of PENDING/FINISHED flags to handle memory accesses, the logic of `em_emulate_insn` is executed few times, but we don't want to apply these "side effects" few times, e.g. decrementing/incrementing the stack pointer at every execution.

By placing a `gpr_cache_flush`, we "commit" the changes on the "done" label, and ensure that side effects occur only once. Note that for REP/REPE/REPNE instructions we also need to flush the GPR cache on each iteration, as such instructions are meant to execute the emulation logic multiple times, e.g. to repeatedly decrement the ~accumulator~ counter.

### Verbose error descriptions in emulator tests (25478d7)

Previously, we added `EXPECT_EQ(memcmp(&vcpu, &vcpu_expected, sizeof(test_cpu_t)), 0);` as a simple check at the end of EmulatorTest::run. While this was enough to catch implementation issues in the emulator, it did specify where the exactly was the mismatch happening. Consequently, we often turn to the debugger and manually diff both `test_cpu_t` structures which is time consuming.

This patch adds a dedicated `EmulatorTest::verify` function that checks each register individually and reports any issues to the stderr, before comparing and asserting the equality of both structures. Note that the previous `EXPECT_EQ` has been replaced with `ASSERT_EQ`, as there is no point in keep trying other instruction variants if there's one broken already.

### Allow emulator tests in 16-bit and 32-bit protected mode (7860a02)

Now we can customize in the `em_context_t::mode` in each test, and provide the `run_prot16`, `run_prot32`, `run_prot64` methods to assemble, decode and emulate instructions. The previous `run` method now defaults to `run_prot64`.

### Added support for PUSH/POP instructions (6d962ac)

- Implemented push/pop instructions in the emulator.
- Added `INSN_STACK` instruction flag to signal push/pop instructions, since the operand size behaves differently than in other instructions.
- Returning `em_status_t` from software-emulated instructions to allow calling operand_read/operand_write within them.
- Adding `ctxt->b` to the emulation context members, since certain variants of push/pop require reading the opcode byte to get the register index.
- Added tests for push/pop instructions.
