### PR TITLE
 Fixed accesses to AH/CH/DH/BH registers in the emulator

### DIFF
--- a/core/emulate.c
+++ b/core/emulate.c
@@ -1182,13 +1182,6 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
     }
 
     /* Apply flags */
-    if (flags & INSN_BYTEOP) {
-        ctxt->operand_size = 1;
-    }
-    if (flags & INSN_STACK) {
-        if (ctxt->operand_size == 4 && ctxt->mode == EM_MODE_PROT64)
-            ctxt->operand_size = 8;
-    }
     if (flags & INSN_GROUP) {
         const struct em_opcode_t *group_opcode;
 
@@ -1199,6 +1192,7 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
         group_opcode = &opcode->group[ctxt->modrm.opc];
         opcode->handler = group_opcode->handler;
         opcode->flags |= group_opcode->flags;
+        flags = opcode->flags;
         if (group_opcode->decode_dst != decode_op_none) {
             opcode->decode_dst = group_opcode->decode_dst;
         }
@@ -1208,6 +1202,13 @@ em_status_t EMCALL em_decode_insn(struct em_context_t *ctxt, const uint8_t *insn
         if (group_opcode->decode_src2 != decode_op_none) {
             opcode->decode_src2 = group_opcode->decode_src2;
         }
+    }
+    if (flags & INSN_BYTEOP) {
+        ctxt->operand_size = 1;
+    }
+    if (flags & INSN_STACK) {
+        if (ctxt->operand_size == 4 && ctxt->mode == EM_MODE_PROT64)
+            ctxt->operand_size = 8;
     }
 
     /* Some unimplemented opcodes have an all-zero em_opcode_t */

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -100,10 +100,8 @@ struct em_operand_t;
 #define EM_OPS_NO_TRANSLATION  (1 << 0)
 
 typedef struct em_vcpu_ops_t {
-    uint64_t (*read_gpr)(void *vcpu, uint32_t reg_index,
-                         uint32_t size);
-    void (*write_gpr)(void *vcpu, uint32_t reg_index,
-                      uint64_t value, uint32_t size);
+    uint64_t (*read_gpr)(void *vcpu, uint32_t reg_index);
+    void (*write_gpr)(void *vcpu, uint32_t reg_index, uint64_t value);
     uint64_t (*read_rflags)(void *vcpu);
     void (*write_rflags)(void *vcpu, uint64_t value);
     uint64_t (*get_segment_base)(void *vcpu, uint32_t segment);
@@ -170,6 +168,11 @@ typedef struct em_context_t {
     struct em_operand_t src1;
     struct em_operand_t src2;
     uint64_t rflags;
+
+    /* Cache */
+    uint64_t gpr_cache[16];
+    uint16_t gpr_cache_r;
+    uint16_t gpr_cache_w;
 
     /* Decoder */
     struct {

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -140,6 +140,7 @@ typedef struct em_operand_t {
         } mem;
         struct operand_reg_t {
             uint32_t index;
+            uint32_t shift;
         } reg;
     };
     uint64_t value;

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -175,6 +175,7 @@ typedef struct em_context_t {
     uint16_t gpr_cache_w;
 
     /* Decoder */
+    uint8_t b;
     struct {
         uint8_t prefix;
         union {

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -2182,27 +2182,24 @@ static int vcpu_emulate_insn(struct vcpu_t *vcpu)
     return HAX_EXIT;
 }
 
-static uint64_t vcpu_read_gpr(void *obj, uint32_t reg_index, uint32_t size)
+static uint64_t vcpu_read_gpr(void *obj, uint32_t reg_index)
 {
     struct vcpu_t *vcpu = obj;
     if (reg_index >= 16) {
         hax_panic_vcpu(vcpu, "vcpu_read_gpr: Invalid register index\n");
         return 0;
     }
-    uint64_t value = 0;
-    memcpy(&value, &vcpu->state->_regs[reg_index], size);
-    return value;
+    return vcpu->state->_regs[reg_index];
 }
 
-static void vcpu_write_gpr(void *obj, uint32_t reg_index, uint64_t value,
-                           uint32_t size)
+static void vcpu_write_gpr(void *obj, uint32_t reg_index, uint64_t value)
 {
     struct vcpu_t *vcpu = obj;
     if (reg_index >= 16) {
         hax_panic_vcpu(vcpu, "vcpu_write_gpr: Invalid register index\n");
         return;
     }
-    memcpy(&vcpu->state->_regs[reg_index], &value, size);
+    vcpu->state->_regs[reg_index] = value;
 }
 
 uint64_t vcpu_read_rflags(void *obj)

--- a/tests/test_emulator.cpp
+++ b/tests/test_emulator.cpp
@@ -55,23 +55,20 @@ struct test_cpu_t {
     uint8_t mem[0x100];
 };
 
-uint64_t test_read_gpr(void* obj, uint32_t reg_index, uint32_t size) {
+uint64_t test_read_gpr(void* obj, uint32_t reg_index) {
     test_cpu_t* vcpu = reinterpret_cast<test_cpu_t*>(obj);
     if (reg_index >= 16) {
         throw std::exception("Register index OOB");
     }
-    uint64_t value = 0;
-    memcpy(&value, &vcpu->gpr[reg_index], size);
-    return value;
+    return vcpu->gpr[reg_index];
 }
 
-void test_write_gpr(void* obj, uint32_t reg_index,
-                    uint64_t value, uint32_t size) {
+void test_write_gpr(void* obj, uint32_t reg_index, uint64_t value) {
     test_cpu_t* vcpu = reinterpret_cast<test_cpu_t*>(obj);
     if (reg_index >= 16) {
         throw std::exception("Register index OOB");
     }
-    memcpy(&vcpu->gpr[reg_index], &value, size);
+    vcpu->gpr[reg_index] = value;
 }
 
 uint64_t test_read_rflags(void* obj) {

--- a/tests/test_emulator.cpp
+++ b/tests/test_emulator.cpp
@@ -889,6 +889,19 @@ TEST_F(EmulatorTest, insn_cmps) {
     run("repe cmpsb", vcpu_original, vcpu_expected);
 }
 
+TEST_F(EmulatorTest, insn_mov) {
+    test_cpu_t vcpu_original;
+    test_cpu_t vcpu_expected;
+
+    // Test: mov r8, r/m8
+    vcpu_original = {};
+    vcpu_original.gpr[REG_RDX] = 0x88;
+    vcpu_original.mem[0x88] = 0x44;
+    vcpu_expected = vcpu_original;
+    vcpu_expected.gpr[REG_RCX] = 0x4400;
+    run("mov ch, [rdx]", vcpu_original, vcpu_expected);
+}
+
 TEST_F(EmulatorTest, insn_movs) {
     test_cpu_t vcpu_original;
     test_cpu_t vcpu_expected;


### PR DESCRIPTION
**This patch depends on #185!**

Implemented by adding a `op->reg.shift` field that indicates the how many bytes does the full-width register need to be right-shifted in order to access the desired value.

This patch fixes #189.
