### PR TITLE
Support stand-alone memory mappings

### DIFF
--- a/core/hax.c
+++ b/core/hax.c
@@ -340,6 +340,7 @@ int hax_get_capability(void *buf, int bufLeng, int *outLength)
         cap->winfo |= HAX_CAP_64BIT_RAMBLOCK;
 #ifdef CONFIG_HAX_EPT2
         cap->winfo |= HAX_CAP_64BIT_SETRAM;
+        cap->winfo |= HAX_CAP_IMPLICIT_RAMBLOCK;
 #endif
         cap->winfo |= HAX_CAP_TUNNEL_PAGE;
         cap->winfo |= HAX_CAP_RAM_PROTECTION;

--- a/core/include/memory.h
+++ b/core/include/memory.h
@@ -55,6 +55,8 @@ typedef struct hax_ramblock {
     uint8_t *chunks_bitmap;
     // Reference count of this object
     int ref_count;
+    // Whether this RAM block is associated with a stand-alone mapping
+    bool is_standalone;
     // Turns this object into a list node
     hax_list_node entry;
 } hax_ramblock;
@@ -75,10 +77,13 @@ typedef struct hax_memslot {
 } hax_memslot;
 
 // Read-only mapping, == HAX_RAM_INFO_ROM in hax_interface.h
-#define HAX_MEMSLOT_READONLY 0x01
+#define HAX_MEMSLOT_READONLY (1 << 0)
+// Stand-alone mapping, == HAX_RAM_INFO_STANDALONE in hax_interface.h
+#define HAX_MEMSLOT_STANDALONE (1 << 6)
+
 // Unmapped, == HAX_RAM_INFO_INVALID in hax_interface.h
-// Used only by memslot_set_mapping(), not by any hax_memslot
-#define HAX_MEMSLOT_INVALID  0x80
+// Not to be used by hax_memslot::flags
+#define HAX_MEMSLOT_INVALID (1 << 7)
 
 typedef struct hax_gpa_prot {
     // A bitmap where each bit represents the protection status of a guest page

--- a/core/memory.c
+++ b/core/memory.c
@@ -235,7 +235,7 @@ static struct hax_vcpu_mem *get_pmem_range(struct vm_t *vm, uint64_t va)
 static int handle_set_ram(struct vm_t *vm, uint64_t start_gpa, uint64_t size,
                           uint64_t start_uva, uint32_t flags)
 {
-    bool unmap = flags & HAX_RAM_INFO_INVALID;
+    bool unmap = flags & HAX_MEMSLOT_INVALID;
     hax_gpa_space *gpa_space;
     uint64_t start_gfn, npages;
     int ret;
@@ -243,7 +243,7 @@ static int handle_set_ram(struct vm_t *vm, uint64_t start_gpa, uint64_t size,
 
     // HAX_RAM_INFO_INVALID indicates that guest physical address range
     // [start_gpa, start_gpa + size) should be unmapped
-    if (unmap && (flags != HAX_RAM_INFO_INVALID || start_uva)) {
+    if (unmap && (flags != HAX_MEMSLOT_INVALID || start_uva)) {
         hax_error("%s: Invalid start_uva=0x%llx or flags=0x%x for unmapping\n",
                   __func__, start_uva, flags);
         return -EINVAL;

--- a/include/hax_interface.h
+++ b/include/hax_interface.h
@@ -193,6 +193,7 @@ struct hax_module_version {
 #define HAX_CAP_TUNNEL_PAGE        (1 << 5)
 #define HAX_CAP_RAM_PROTECTION     (1 << 6)
 #define HAX_CAP_DEBUG              (1 << 7)
+#define HAX_CAP_IMPLICIT_RAMBLOCK  (1 << 8)
 
 struct hax_capabilityinfo {
     /*
@@ -240,8 +241,13 @@ struct hax_ramblock_info {
     uint64_t reserved;
 } PACKED;
 
-#define HAX_RAM_INFO_ROM     0x01  // read-only
-#define HAX_RAM_INFO_INVALID 0x80  // unmapped, usually used for MMIO
+// Read-only mapping
+#define HAX_RAM_INFO_ROM (1 << 0)
+// Stand-alone mapping into a new HVA range
+#define HAX_RAM_INFO_STANDALONE (1 << 6)
+
+// Unmapped, usually used for MMIO
+#define HAX_RAM_INFO_INVALID (1 << 7)
 
 struct hax_set_ram_info {
     uint64_t pa_start;


### PR DESCRIPTION
Android Emulator may dynamically create and destroy temporary
memory mappings at guest runtime for certain rendering tasks via
hax_user_backed_ram_map() and hax_user_backed_ram_unmap()
($AOSP/external/qemu/target/i386/hax-mem.c), e.g.:

 hax_user_backed_ram_map() <1>
 1.1) ADD_RAMBLOCK <1>:     HVA 0x14e070000..0x16e070000
 1.2) SET_RAM2 (map) <1>:   GPA 0x7dffff000..0x7fffff000 =>
                            HVA 0x14e070000..0x16e070000
 hax_user_backed_ram_unmap() <1>
 1.3) SET_RAM2 (unmap) <1>: GPA 0x7dffff000..0x7fffff000
 hax_user_backed_ram_map() <2>
 2.1) ADD_RAMBLOCK <2>:     HVA 0x14de70000..0x16de70000

The second ADD_RAMBLOCK call fails, because its HVA range overlaps
with that of the first ADD_RAMBLOCK call.

The problem is that the "map" step creates a RAM block, but the
"unmap" step doesn't destroy it. Instead of adding a DEL_RAMBLOCK
ioctl, simply exempt the caller from calling ADD_RAMBLOCK in the
first place:

 - Introduce a new hax_memslot flag for "stand-alone" mappings,
   along with a new capability flag for this API change.
 - Remove the ADD_RAMBLOCK call from hax_user_backed_ram_map().
   Instead, call SET_RAM2 with the new flag. (This will be done on
   the Android Emulator side.)
 - Internally, SET_RAM2 creates a stand-alone RAM block for each
   stand-alone mapping.
 - When the stand-alone mapping is unmapped, the reference count
   of the corresponding stand-alone RAM block will hit 0, which
   allows SET_RAM2 to destroy this temporary RAM block.

+ Replace HAX_RAM_INFO_xxx with HAX_MEMSLOT_xxx in code that is
  not directly in touch with user space.