### PR TITLE
Windows10 guest support

### DIFF
--- a/core/include/compiler.h
+++ b/core/include/compiler.h
@@ -43,7 +43,7 @@
 // a non-POD structure.
 // We have to use 1 instead of 0 so the compiler doesn't generate an error.
 #define offsetof(type, mem) \
-        ((uint32)((char *)&((const type *)1)->mem - (char *)((const type *)1)))
+        ((uint32_t)((char *)&((const type *)1)->mem - (char *)((const type *)1)))
 
 #define ALWAYS_INLINE           __attribute__ ((always_inline))
 #define NOINLINE                __attribute__ ((noinline))

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -84,6 +84,7 @@ struct hstate {
     uint64_t dr7;
     // CR0
     bool cr0_ts;
+    uint64_t _pat;
 };
 
 struct hstate_compare {

--- a/core/include/hax_core_interface.h
+++ b/core/include/hax_core_interface.h
@@ -45,6 +45,7 @@ int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_get_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *vs);
 int vcpu_get_regs(struct vcpu_t *vcpu, struct vcpu_state_t *vs);
+int vcpu_get_state_size(struct vcpu_t *vcpu);
 void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug);
 
 void * get_vcpu_host(struct vcpu_t *vcpu);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -173,6 +173,7 @@ struct vcpu_t {
     struct vm_t *vm;
     struct hax_mmu *mmu;
     struct vcpu_state_t *state;
+    uint64_t _cr8;
     struct hax_tunnel *tunnel;
     uint8_t *io_buf;
     struct hax_page *vmcs_page;
@@ -262,6 +263,7 @@ int vcpu_get_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_get_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t *val);
 int vcpu_put_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val);
+int vcpu_get_state_size(struct vcpu_t *vcpu);
 void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug);
 
 /* The declaration for OS wrapper code */

--- a/core/include/vm.h
+++ b/core/include/vm.h
@@ -62,6 +62,7 @@ struct vm_t {
     uint64_t flags;
 #define VM_FEATURES_FASTMMIO_BASIC 0x1
 #define VM_FEATURES_FASTMMIO_EXTRA 0x2
+#define VM_FEATURES_CR8            0x4
     uint32_t features;
     int vm_id;
 #define VPID_SEED_BITS 64

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -2713,10 +2713,13 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t a, uint32_t c)
             state->_edx = 0x0c040844;
             return;
         }
-        case 3:                         // Reserved
+        case 3: {                       // Reserved
+            state->_eax = state->_ebx = state->_ecx = state->_edx = 0;
+            return;
+        }
         case 4: {                       // Deterministic Cache Parameters
             // [31:26] cores per package - 1
-            state->_eax = state->_ebx = state->_ecx = state->_edx = 0;
+            // Use host cache values.
             return;
         }
         case 5:                         // MONITOR/MWAIT

--- a/core/vm.c
+++ b/core/vm.c
@@ -73,6 +73,9 @@ int hax_vm_set_qemuversion(struct vm_t *vm, struct hax_qemu_version *ver)
         vm->features |= VM_FEATURES_FASTMMIO_BASIC;
         if (ver->cur_version >= 0x4) {
             vm->features |= VM_FEATURES_FASTMMIO_EXTRA;
+            if (ver->cur_version >= 0x5) {
+                vm->features |= VM_FEATURES_CR8;
+            }
         }
     }
     return 0;

--- a/include/hax.h
+++ b/include/hax.h
@@ -39,7 +39,7 @@
 // declaration
 struct vcpu_t;
 
-#define HAX_CUR_VERSION    0x0004
+#define HAX_CUR_VERSION    0x0005
 #define HAX_COMPAT_VERSION 0x0001
 
 // EPT2 refers to the new memory virtualization engine, which implements lazy

--- a/include/vcpu_state.h
+++ b/include/vcpu_state.h
@@ -188,6 +188,8 @@ struct vcpu_state_t {
     uint32_t _activity_state;
     uint32_t pad;
     interruptibility_state_t _interruptibility_state;
+
+    uint64_t _cr8;
 } PACKED;
 
 void dump(void);

--- a/platforms/linux/components.c
+++ b/platforms/linux/components.c
@@ -411,7 +411,8 @@ static long hax_vcpu_ioctl(struct file *filp, unsigned int cmd,
     }
     case HAX_VCPU_SET_REGS: {
         struct vcpu_state_t vc_state;
-        if (copy_from_user(&vc_state, argp, sizeof(vc_state))) {
+        int size = vcpu_get_state_size(cvcpu);
+        if (copy_from_user(&vc_state, argp, size)) {
             ret = -EFAULT;
             break;
         }
@@ -420,8 +421,9 @@ static long hax_vcpu_ioctl(struct file *filp, unsigned int cmd,
     }
     case HAX_VCPU_GET_REGS: {
         struct vcpu_state_t vc_state;
+        int size = vcpu_get_state_size(cvcpu);
         ret = vcpu_get_regs(cvcpu, &vc_state);
-        if (copy_to_user(argp, &vc_state, sizeof(vc_state))) {
+        if (copy_to_user(argp, &vc_state, size)) {
             ret = -EFAULT;
             break;
         }

--- a/platforms/windows/hax_entry.c
+++ b/platforms/windows/hax_entry.c
@@ -387,7 +387,7 @@ NTSTATUS HaxVcpuControl(PDEVICE_OBJECT DeviceObject,
         }
         case HAX_VCPU_SET_REGS: {
             struct vcpu_state_t *vc_state;
-            if(inBufLength < sizeof(struct vcpu_state_t)) {
+            if (inBufLength < vcpu_get_state_size(cvcpu)) {
                 ret = STATUS_INVALID_PARAMETER;
                 goto done;
             }
@@ -398,7 +398,8 @@ NTSTATUS HaxVcpuControl(PDEVICE_OBJECT DeviceObject,
         }
         case HAX_VCPU_GET_REGS: {
             struct vcpu_state_t *vc_state;
-            if(outBufLength < sizeof(struct vcpu_state_t)) {
+            infret = vcpu_get_state_size(cvcpu);
+            if (outBufLength < infret) {
                 ret = STATUS_INVALID_PARAMETER;
                 goto done;
 
@@ -406,7 +407,6 @@ NTSTATUS HaxVcpuControl(PDEVICE_OBJECT DeviceObject,
             vc_state = (struct vcpu_state_t *)outBuf;
             // vcpu_get_regs() cannot fail
             vcpu_get_regs(cvcpu, vc_state);
-            infret = sizeof(struct vcpu_state_t);
             break;
         }
         case HAX_VCPU_IOCTL_INTERRUPT: {


### PR DESCRIPTION
Added more supported features to cpuid and PAT MSR support. This enables to install and run a windows10 x86 guest. Windows10 x64 guests are not yet working, since the amount of CR8 reads\writes is very big and the loading process stucks on handling them.
The patch was tested on a windows 7 and windows 10 guests on a windows10x64 host.
There are open questions:
1) cr_pat is not read\written to qemu. Thus PAT MSR is not saved\restored from snapshots. I don't know how to add this support, since hax does not provide it's version to qemu, so qemu would not be able to take different actions for different hax versions - read cr_pat from the new version and don't read from the old. The same for CR8 register.
2) in vcpu.c on line 2020 both the local and the vcpu object versions of entry_ctls are modified. This makes it possible that the check at line 2043 will be false and entry controls are not saved to vmcs. Is this OK?
3) In cpuid filtering there are such checks:
 if (cpu_has_feature(X86_FEATURE_AESNI)) {
        cpuid_1_features_ecx |= FEATURE(AESNI);
    }
Is this really necessary, given that the function returns the intersection of cpuid_1_features_ecx and the value returned by host cpuid:
state->_ecx = (cpuid_1_features_ecx & state->_ecx) | FEATURE(HYPERVISOR);
?