### PR TITLE
vcpu: Update EFER state for set/get_regs

### DIFF
--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -3878,6 +3878,9 @@ int vcpu_get_regs(struct vcpu_t *vcpu, struct vcpu_state_t *ustate)
     ustate->_dr3 = state->_dr3;
     ustate->_dr6 = state->_dr6;
     ustate->_dr7 = state->_dr7;
+
+    ustate->_efer = state->_efer;
+
     _copy_desc(&state->_cs, &ustate->_cs);
     _copy_desc(&state->_ds, &ustate->_ds);
     _copy_desc(&state->_es, &ustate->_es);
@@ -3907,7 +3910,7 @@ int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *ustate)
 {
     struct vcpu_state_t *state = vcpu->state;
     int i;
-    int cr_dirty = 0, dr_dirty = 0;
+    int cr_dirty = 0, dr_dirty = 0, efer_dirty = 0;
     preempt_flag flags;
     int rsp_dirty = 0;
     uint32_t vmcs_err = 0;
@@ -3946,6 +3949,11 @@ int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *ustate)
     UPDATE_VCPU_STATE(_cr4, cr_dirty);
     if (cr_dirty) {
         vmwrite_cr(vcpu);
+    }
+
+    UPDATE_VCPU_STATE(_efer, efer_dirty);
+    if (efer_dirty) {
+        vmwrite_efer(vcpu);
     }
 
     /*


### PR DESCRIPTION
HAXM didn't return the correct EFER value (tested on the same guest code against WHPX).
Without this you can only get it by reading the MSR directly.