### PR TITLE
Fix compiling warnings and errors on Linux.

### DIFF
--- a/core/gpa_space.c
+++ b/core/gpa_space.c
@@ -244,7 +244,7 @@ int gpa_space_write_data(hax_gpa_space *gpa_space, uint64_t start_gpa, int len,
 {
     uint8_t *buf;
     hax_kmap_user kmap;
-    bool writable;
+    bool writable = false;
     int ret, nbytes;
 
     if (!data) {

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -657,6 +657,7 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
 #define vmwrite(vcpu, x, y) vmx_vmwrite(vcpu, #x, x, y)
 
 #define VMREAD_SEG(vcpu, seg, val)                                 \
+    do {                                                           \
         ((val).selector = vmread(vcpu, GUEST_##seg##_SELECTOR),    \
          (val).base     = vmread(vcpu, GUEST_##seg##_BASE),        \
          (val).limit    = vmread(vcpu, GUEST_##seg##_LIMIT),       \
@@ -664,7 +665,8 @@ void vmx_vmwrite(struct vcpu_t *vcpu, const char *name,
         {                                                          \
             if ((val).null == 1)                                   \
                 (val).ar = 0;                                      \
-        }
+        }                                                          \
+    } while (false)
 
 #define VMREAD_DESC(vcpu, desc, val)                               \
         ((val).base  = vmread(vcpu, GUEST_##desc##_BASE),          \

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1414,9 +1414,9 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
     vmwrite(vcpu, HOST_GDTR_BASE, get_kernel_gdtr_base());
     vmwrite(vcpu, HOST_IDTR_BASE, get_kernel_idtr_base());
 
-#define WRITE_CONTROLS(vcpu, f, v) {                                    \
-    uint32_t g = v & cpu_data->vmx_info.v##_1 | cpu_data->vmx_info.v##_0; \
-    vmwrite(vcpu, f, v = g);                                            \
+#define WRITE_CONTROLS(vcpu, f, v) {                                        \
+    uint32_t g = (v & cpu_data->vmx_info.v##_1) | cpu_data->vmx_info.v##_0; \
+    vmwrite(vcpu, f, v = g);                                                \
 }
 
     WRITE_CONTROLS(vcpu, VMX_PIN_CONTROLS, pin_ctls);
@@ -2509,6 +2509,7 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t a, uint32_t c)
     struct vcpu_state_t *state = vcpu->state;
     uint32_t hw_family;
     uint32_t hw_model;
+    uint8_t physical_address_size;
 
     static uint32_t cpu_features_1 =
             // pat is disabled!
@@ -2556,8 +2557,6 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t a, uint32_t c)
     if (cpu_has_feature(X86_FEATURE_RDTSCP)) {
         cpu_features_ext |= FEATURE(RDTSCP);
     }
-
-    uint8_t physical_address_size;
 
     switch (a) {
         case 0: {                       // Maximum Basic Information
@@ -3810,7 +3809,6 @@ static int exit_ept_violation(struct vcpu_t *vcpu, struct hax_tunnel *htun)
         return HAX_RESUME;
     }
     // ret == 0: The EPT violation is due to MMIO
-mmio_handler:
 #endif
     return vcpu_emulate_insn(vcpu);
 }

--- a/include/linux/hax_types_linux.h
+++ b/include/linux/hax_types_linux.h
@@ -33,7 +33,9 @@
 #define HAX_LINUX_HAX_TYPES_LINUX_H_
 
 #include <linux/types.h>
+#define _ASM_X86_CPUFEATURES_H
 #include <linux/string.h>
+#undef _ASM_X86_CPUFEATURES_H
 #include <linux/errno.h>
 
 // Signed Types


### PR DESCRIPTION
Below warnings and errors are fixed:
-Wmaybe-uninitialized in gpa_space_write_data().
-Wmultistatement-macros of macro VMREAD_SEG.
-Wparentheses of macro WRITE_CONTROLS.
-Wdeclaration-after-statement in handle_cpuid_virtual();
-Wunused-label in exit_ept_violation().
Conflict X86_FEATURE_x definition in cpuid.h and cpufeatures.h.

Signed-off-by: Colin Xu <colin.xu@intel.com>