### PR TITLE
Fix incorrect VMX_ENTRY_CONTROLS loading.

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -624,8 +624,7 @@ void load_vmcs_common(struct vcpu_t *vcpu)
 
     vmx(vcpu, exc_bitmap) = vmx(vcpu, exc_bitmap_base) = vmread(
             vcpu, VMX_EXCEPTION_BITMAP);
-    vmx(vcpu, entry_ctls) = vmx(vcpu, entry_ctls_base) = vmread(
-            vcpu, VMX_ENTRY_CONTROLS);
+    vmx(vcpu, entry_ctls) = vmread(vcpu, VMX_ENTRY_CONTROLS);
     vmx(vcpu, exit_ctls) = vmx(vcpu, exit_ctls_base) = vmread(
             vcpu, VMX_EXIT_CONTROLS);
 

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -72,7 +72,6 @@ struct vcpu_vmx_data {
     uint32_t pin_ctls_base;
     uint32_t pcpu_ctls_base;
     uint32_t scpu_ctls_base;
-    uint32_t entry_ctls_base;
     uint32_t exc_bitmap_base;
     uint32_t exit_ctls_base;
 


### PR DESCRIPTION
There exists some issue when programming VMX_ENTRY_CONTROLS and GUEST_EFER:
- ENTRY_CONTROL_LONG_MODE_GUEST has no chance to clear.
- vmwrite_efer() called by vmwrite_cr() will check vmx field before
vmx field gets updated, and itself will also program VMX_ENTRY_CONTROLS,
which may cause incorrect VMX_ENTRY_CONTROLS programmed.
- vmx filed entry_ctls_base and entry_ctls are loaded from vmcs in:
vcpu_create()->vcpu_prepare()->fill_common_vmcs()->load_vmcs_common().
When vmwrite_cr() and vmwrite_efer() write a dirty VMX_ENTRY_CONTROLS,
it only updates vmx field entry_ctls, but it compares with value of
entry_ctls_base for dirty check, which may cause reduntant or miss
programming to VMX_ENTRY_CONTROLS.

Below changes are made:
- Add the missing clear of ENTRY_CONTROL_LONG_MODE_GUEST.
- Move vmwrite_efer() to last of vmwrite_cr() after VMX_ENTRY_CONTROLS
  programmed.
- Remove unnecessary entry_ctls_base in vmx field.

Signed-off-by: Colin Xu <colin.xu@intel.com>