### PR TITLE
set PCLMULQDQ in feature informantion of CPUID

### DIFF
--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -2572,6 +2572,9 @@ static void handle_cpuid_virtual(struct vcpu_t *vcpu, uint32_t a, uint32_t c)
     if (cpu_has_feature(X86_FEATURE_AESNI)) {
         cpu_features_2 |= FEATURE(AESNI);
     }
+    if (cpu_has_feature(X86_FEATURE_PCLMULQDQ)) {
+        cpu_features_2 |= FEATURE(PCLMULQDQ);
+    }
     if (cpu_has_feature(X86_FEATURE_RDTSCP)) {
         cpu_features_ext |= FEATURE(RDTSCP);
     }


### PR DESCRIPTION
CTS 'test_SSLSocket_getHandshankeSession_duringHandshake' relys on
PCLMULQDQ feature. Enable it in CPUID emulation if host can support.

The instructions of this feature may have MMIO operand. Need to add
their emulation if there is real case to use MMIO operand.

Signed-off-by: Hang Yuan <hang.yuan@intel.com>