### PR TITLE
Fix macOS build failure on SDK 10.12 and host crash.

### DIFF
--- a/platforms/darwin/hax_wrapper.cpp
+++ b/platforms/darwin/hax_wrapper.cpp
@@ -64,7 +64,7 @@ extern "C" void hax_log(int level, const char *fmt, ...)
     va_start(args, fmt);
     if (level >= HAX_LOG_DEFAULT) {
         printf("%s", kLogPrefix[level]);
-        printf(fmt, args);
+        vprintf(fmt, args);
     }
     va_end(args);
 }
@@ -74,7 +74,7 @@ extern "C" void hax_panic(const char *fmt, ...)
     va_list args;
     va_start(args, fmt);
     hax_log(HAX_LOGPANIC, fmt, args);
-    panic(fmt, args);
+    (panic)(fmt, args);
     va_end(args);
 }
 


### PR DESCRIPTION
Macro panic() is expand to postfix with panic line number, when passing
a va_list to panic(), the macro can't expand correctly.
Since panic() is now wrapped with hax_panic(), the line number always
points inside hax_panic() which isn't necessary.
Use panic_plain instead.

Before hax logger refine, hax_log_level() incorrectly use printf() for
va_list. However it should use vprintf(). The new hax_log() inherits
from hax_log_level() but doens't fix printf()->vprintf().

Signed-off-by: Colin Xu <colin.xu@intel.com>