### PR TITLE
Fix incorrect interruptibility_state before vmx entry.

### DIFF
--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -502,6 +502,12 @@ enum {
     GAS_CSTATE      = 4
 };
 
+// Intel SDM Vol. 3C: Table 24-3. Format of Interruptibility State
+#define GUEST_INTRSTAT_STI_BLOCKING            0x00000001
+#define GUEST_INTRSTAT_SS_BLOCKING             0x00000002
+#define GUEST_INTRSTAT_SMI_BLOCKING            0x00000004
+#define GUEST_INTRSTAT_NMI_BLOCKING            0x00000008
+
 #ifdef HAX_COMPILER_MSVC
 #pragma pack(push, 1)
 #endif

--- a/core/intr_exc.c
+++ b/core/intr_exc.c
@@ -121,12 +121,15 @@ uint hax_intr_is_blocked(struct vcpu_t *vcpu)
 {
     struct vcpu_state_t *state = vcpu->state;
     uint32_t intr_status;
+    uint32_t intr_blocking = 0;
 
     if (!(state->_eflags & EFLAGS_IF))
         return 1;
 
+    intr_blocking |= GUEST_INTRSTAT_STI_BLOCKING;
+    intr_blocking |= GUEST_INTRSTAT_SS_BLOCKING;
     intr_status = vmx(vcpu, interruptibility_state).raw;
-    if (intr_status & 3)
+    if (intr_status & intr_blocking)
         return 1;
     return 0;
 }


### PR DESCRIPTION
According to SDM 26.3.1.5 Checks on Guest Non-Register State, Bit 0
(blocking by STI) must be 0 if the IF flag (bit 9) is 0 in the RFLAGS
field.
There is an issue during snapshot loading, that IF and
interruptibility_state don't pass the checks, which will result in
VM-entry failure due to invalid guest state.
This WA correct the bit so that vmx entry check could pass. The normal
interruptibility_state update is done when advancing the IP.
In future, proper approach is expected to replace the WA.

Signed-off-by: Colin Xu <colin.xu@intel.com>