### PR TITLE
memslot: Fix a bug of memslot_move()

### DIFF
--- a/core/memslot.c
+++ b/core/memslot.c
@@ -380,7 +380,9 @@ static inline void memslot_delete(hax_memslot *dest)
 static inline void memslot_move(hax_memslot *dest, hax_memslot *src)
 {
     ramblock_deref(dest->block);
-    memslot_init(dest, src);
+    src->entry = dest->entry;
+    *dest = *src;
+    ramblock_ref(dest->block);
 }
 
 static inline void memslot_union(hax_memslot *dest, hax_memslot *src)


### PR DESCRIPTION
Invoking memslot_init() in memslot_move() will result in losing the
linked list information of the original memory slot node. Reimplement
memslot_move() to resolve some exceptional issues during mapping memory
slots.

Signed-off-by: leecher1337 <leecher@dose.0wnz.at>