### PR TITLE
Add VM pause support

### DIFF
--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1711,6 +1711,14 @@ int vcpu_execute(struct vcpu_t *vcpu)
             goto out;
         }
     }
+
+    // Check if Qemu pauses VM
+    if (htun->_exit_reason == HAX_EXIT_PAUSED) {
+        htun->_exit_status = HAX_EXIT_PAUSED;
+        hax_log(HAX_LOGD, "vcpu paused\n");
+        goto out;
+    }
+
     err = cpu_vmx_execute(vcpu, htun);
     vcpu_is_panic(vcpu);
 out:


### PR DESCRIPTION
Check if Qemu wants to pause VM. If yes, don't enter guest. This is
helpful in snapshot scenario that Qemu can tell HAXM to pause after
it finishes last guest IO/MMIO instruction.

Signed-off-by: Hang Yuan <hang.yuan@intel.com>