### PR TITLE
mac: Update macOS SDK version

### DIFF
--- a/platforms/darwin/intelhaxm.xcodeproj/project.pbxproj
+++ b/platforms/darwin/intelhaxm.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-fstack-protector-strong";
 				PREBINDING = NO;
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx10.12;
 				USE_HEADERMAPS = NO;
 			};
 			name = Debug;
@@ -557,7 +557,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_CFLAGS = "-fstack-protector-strong";
 				PREBINDING = NO;
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx10.12;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Change default macOS SDK version to 10.12 according to current macOS
supported version.

Signed-off-by: Wenchao Wang <wenchao.wang@intel.com>