### PR TITLE
Move selector validity checking to vcpu_set_regs

### DIFF
--- a/core/cpu.c
+++ b/core/cpu.c
@@ -370,29 +370,6 @@ int cpu_vmx_execute(struct vcpu_t *vcpu, struct hax_tunnel *htun)
         vcpu_handle_vmcs_pending(vcpu);
         vcpu_inject_intr(vcpu, htun);
 
-        /* sometimes, the code segment type from qemu can be 10 (code segment),
-         * this will cause invalid guest state, since 11 (accessed code segment),
-         * not 10 is required by vmx hardware. Note: 11 is one of the allowed
-         * values by vmx hardware.
-         */
-        {
-            uint32_t temp= vmread(vcpu, GUEST_CS_AR);
-
-            if( (temp & 0xf) == 0xa) {
-                temp = temp +1;
-                vmwrite(vcpu, GUEST_CS_AR, temp);
-            }
-        }
-        /* sometimes, the TSS segment type from qemu is not right.
-         * let's hard-code it for now
-         */
-        {
-            uint32_t temp = vmread(vcpu, GUEST_TR_AR);
-
-            temp = (temp & ~0xf) | 0xb;
-            vmwrite(vcpu, GUEST_TR_AR, temp);
-        }
-
         res = cpu_vmx_run(vcpu, htun);
         if (res) {
             hax_log(HAX_LOGE, "cpu_vmx_run error, code:%x\n", res);

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -4107,6 +4107,19 @@ int vcpu_set_regs(struct vcpu_t *vcpu, struct vcpu_state_t *ustate)
             vcpu->dr_dirty = 0;
     }
 
+    /* sometimes, the code segment type from qemu can be 10 (code segment),
+     * this will cause invalid guest state, since 11 (accessed code segment),
+     * not 10 is required by vmx hardware. Note: 11 is one of the allowed
+     * values by vmx hardware.
+     */
+    if( (state->_cs.ar & 0xf) == 0xa)
+        state->_cs.ar = state->_cs.ar +1;
+
+    /* sometimes, the TSS segment type from qemu is not right.
+     * let's hard-code it for now
+     */
+    state->_tr.ar = (state->_tr.ar & ~0xf) | 0xb;
+
     UPDATE_SEGMENT_STATE(CS, _cs);
     UPDATE_SEGMENT_STATE(DS, _ds);
     UPDATE_SEGMENT_STATE(ES, _es);


### PR DESCRIPTION
Comments to cs.ar and tr.ar validity checking stating that these can be wrong set by qemu. But the checks were done before every vmentry with reading the values from vmcs and that is bad for performance. I moved the checks to vcpu_set_regs since qemu sets them through this function. I did not found any other places that write these to vmcs.

