### PR TITLE
Make HAXM run on system with more than 64 host CPUs

### DIFF
--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -44,8 +44,6 @@
 struct vcpu_t;
 struct vcpu_state_t;
 
-typedef uint32_t hax_cpuid_t;  // CPU identifier
-
 #define NR_HMSR 6
 
 struct hstate {
@@ -103,7 +101,7 @@ struct per_cpu_data {
     struct hax_page    *vmcs_page;
     struct vcpu_t      *current_vcpu;
     hax_paddr_t        other_vmcs;
-    hax_cpuid_t        cpu_id;
+    uint32_t           cpu_id;
     uint16_t           vmm_flag;
     uint16_t           nested;
     mword              host_cr4_vmxe;
@@ -157,8 +155,7 @@ struct per_cpu_data {
 extern struct per_cpu_data ** hax_cpu_data;
 static struct per_cpu_data * current_cpu_data(void)
 {
-    uint32_t cpu_id = hax_cpuid();
-    return hax_cpu_data[cpu_id];
+    return hax_cpu_data[hax_cpu_id()];
 }
 
 static struct per_cpu_data * get_cpu_data(uint32_t cpu_id)

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -146,9 +146,9 @@ struct mmio_fetch_cache {
 
 struct vcpu_t {
     uint16_t vcpu_id;
-    uint16_t cpu_id;
+    uint32_t cpu_id;
     // Sometimes current thread might be migrated to other core.
-    uint16_t prev_cpu_id;
+    uint32_t prev_cpu_id;
     /*
      * VPID: Virtual Processor Identifier
      * VPIDs provide a way for software to identify to the processor

--- a/include/darwin/hax_mac.h
+++ b/include/darwin/hax_mac.h
@@ -171,21 +171,4 @@ static inline errno_t memcpy_s(void *dest, size_t destsz, const void *src,
 
 #define hax_assert(condition) assert(condition)
 
-static inline bool cpu_is_online(int cpu)
-{
-    if (cpu < 0 || cpu >= max_cpus)
-        return 0;
-    return !!(((uint64_t)1 << cpu) & cpu_online_map);
-}
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-extern int cpu_number(void);
-
-#ifdef __cplusplus
-}
-#endif
-
 #endif  // HAX_DARWIN_HAX_MAC_H_

--- a/include/darwin/hax_types_mac.h
+++ b/include/darwin/hax_types_mac.h
@@ -132,12 +132,9 @@ typedef struct hax_kmap_phys {
 
 typedef ulong mword;
 typedef mword preempt_flag;
-typedef uint64_t hax_cpumap_t;
+typedef uint64_t hax_cpumask_t;
+typedef void hax_smp_func_ret_t;
 typedef uint64_t HAX_VADDR_T;
 
-static inline hax_cpumap_t cpu2cpumap(int cpu)
-{
-    return (0x1UL << cpu);
-}
 #endif  // CONFIG_KERNEL_HAX
 #endif  // HAX_DARWIN_HAX_TYPES_MAC_H_

--- a/include/linux/hax_linux.h
+++ b/include/linux/hax_linux.h
@@ -98,13 +98,6 @@ static inline int memcpy_s(void *dest, size_t destsz, const void *src,
 bool hax_cmpxchg32(uint32_t old_val, uint32_t new_val, volatile uint32_t *addr);
 bool hax_cmpxchg64(uint64_t old_val, uint64_t new_val, volatile uint64_t *addr);
 
-static inline bool cpu_is_online(int cpu)
-{
-    if (cpu < 0 || cpu >= max_cpus)
-        return 0;
-    return !!(((mword)1 << cpu) & cpu_online_map);
-}
-
 int hax_notify_host_event(enum hax_notify_event event, uint32_t *param,
                           uint32_t size);
 

--- a/include/linux/hax_types_linux.h
+++ b/include/linux/hax_types_linux.h
@@ -91,12 +91,8 @@ typedef struct hax_kmap_phys {
 
 typedef struct hax_spinlock hax_spinlock;
 
-typedef int hax_cpumap_t;
-
-static inline hax_cpumap_t cpu2cpumap(int cpu)
-{
-    return (0x1 << cpu);
-}
+typedef uint64_t hax_cpumask_t;
+typedef void hax_smp_func_ret_t;
 
 /* Remove this later */
 #define is_leaf(x)  1

--- a/include/netbsd/hax_netbsd.h
+++ b/include/netbsd/hax_netbsd.h
@@ -97,13 +97,6 @@ static inline int memcpy_s(void *dest, size_t destsz, const void *src,
 bool hax_cmpxchg32(uint32_t old_val, uint32_t new_val, volatile uint32_t *addr);
 bool hax_cmpxchg64(uint64_t old_val, uint64_t new_val, volatile uint64_t *addr);
 
-static inline bool cpu_is_online(int cpu)
-{
-    if (cpu < 0 || cpu >= max_cpus)
-        return 0;
-    return !!(((mword)1 << cpu) & cpu_online_map);
-}
-
 int hax_notify_host_event(enum hax_notify_event event, uint32_t *param,
                           uint32_t size);
 

--- a/include/netbsd/hax_types_netbsd.h
+++ b/include/netbsd/hax_types_netbsd.h
@@ -91,12 +91,8 @@ typedef struct hax_kmap_phys {
 
 typedef struct hax_spinlock hax_spinlock;
 
-typedef int hax_cpumap_t;
-
-static inline hax_cpumap_t cpu2cpumap(int cpu)
-{
-    return (0x1 << cpu);
-}
+typedef uint64_t hax_cpumask_t;
+typedef void hax_smp_func_ret_t;
 
 /* Remove this later */
 #define is_leaf(x)  1

--- a/include/windows/hax_types_windows.h
+++ b/include/windows/hax_types_windows.h
@@ -45,14 +45,6 @@ typedef unsigned char bool;
 #define is_leaf(x)  1
 #endif
 
-typedef KAFFINITY hax_cpumap_t;
-inline hax_cpumap_t cpu2cpumap(int cpu)
-{
-    return ((KAFFINITY)0x1 << cpu);
-}
-
-typedef KIRQL preempt_flag;
-
 // Signed Types
 typedef signed char         int8_t;
 typedef signed short        int16_t;
@@ -67,6 +59,15 @@ typedef unsigned long long  uint64_t;
 typedef unsigned int        uint;
 typedef unsigned long       ulong;
 typedef unsigned long       ulong_t;
+
+// KAFFINITY is 32 bits on a 32-bit version of Windows and is 64 bits
+//   on a 64-bit version of Windows. We always use 64-bit to store CPU mask
+//   in haxm so define it as 64-bit here.
+//typedef KAFFINITY hax_cpumask_t;
+typedef uint64_t hax_cpumask_t;
+typedef ULONG_PTR hax_smp_func_ret_t;
+
+typedef KIRQL preempt_flag;
 
 #include "../hax_list.h"
 struct hax_page {

--- a/include/windows/hax_windows.h
+++ b/include/windows/hax_windows.h
@@ -184,13 +184,6 @@ static bool hax_cmpxchg64(uint64_t old_val, uint64_t new_val, volatile uint64_t 
         return FALSE;
 }
 
-static inline bool cpu_is_online(int cpu)
-{
-    if (cpu < 0 || cpu >= max_cpus)
-        return 0;
-    return !!(((mword)1 << cpu) & cpu_online_map);
-}
-
 int hax_notify_host_event(enum hax_notify_event event, uint32_t *param,
                           uint32_t size);
 

--- a/platforms/linux/hax_entry.c
+++ b/platforms/linux/hax_entry.c
@@ -114,24 +114,24 @@ static long hax_dev_ioctl(struct file *filp, unsigned int cmd,
 
 static int __init hax_driver_init(void)
 {
-    int i, err;
+    int err;
 
-    // Initialization
-    max_cpus = num_present_cpus();
-    cpu_online_map = 0;
-    for (i = 0; i < max_cpus; i++) {
-        if (cpu_online(i))
-            cpu_online_map |= (1ULL << i);
+    err = cpu_info_init();
+    if (err) {
+        hax_log(HAX_LOGE, "Failed to initialize CPU info\n");
+        return err;
     }
 
     if (hax_module_init() < 0) {
         hax_log(HAX_LOGE, "Failed to initialize HAXM module\n");
+        cpu_info_exit();
         return -EAGAIN;
     }
 
     err = misc_register(&hax_dev);
     if (err) {
         hax_log(HAX_LOGE, "Failed to register HAXM device\n");
+        cpu_info_exit();
         hax_module_exit();
         return err;
     }

--- a/platforms/linux/hax_wrapper.c
+++ b/platforms/linux/hax_wrapper.c
@@ -40,9 +40,6 @@
 
 #include <asm/cmpxchg.h>
 
-int max_cpus;
-hax_cpumap_t cpu_online_map;
-
 static const char* kLogLevel[] = {
     KERN_ERR,
     KERN_DEBUG,     // HAX_LOGD
@@ -84,27 +81,88 @@ void hax_panic(const char *fmt, ...)
     va_end(args);
 }
 
-uint32_t hax_cpuid(void)
+inline uint32_t hax_cpu_id(void)
 {
-    return smp_processor_id();
+    return (uint32_t)smp_processor_id();
 }
 
-typedef struct smp_call_parameter {
-    void (*func)(void *);
-    void *param;
-    hax_cpumap_t *cpus;
-} smp_call_parameter;
-
-static void smp_cfunction(void *p)
+int cpu_info_init(void)
 {
-    struct smp_call_parameter *info = p;
-    hax_cpumap_t *cpus;
-    uint32_t cpuid;
+    uint32_t size_group, size_pos, cpu_id, group, bit;
+    hax_cpumap_t omap = {0};
 
-    cpus = info->cpus;
-    cpuid = hax_cpuid();
-    if (*cpus & (0x1 << cpuid))
-        info->func(info->param);
+    memset(&cpu_online_map, 0, sizeof(cpu_online_map));
+
+    cpu_online_map.cpu_num = num_online_cpus();
+    group = HAX_MAX_CPU_PER_GROUP;
+    cpu_online_map.group_num = (cpu_online_map.cpu_num + group - 1) / group;
+    size_group = cpu_online_map.group_num * sizeof(*cpu_online_map.cpu_map);
+    size_pos = cpu_online_map.cpu_num * sizeof(*cpu_online_map.cpu_pos);
+
+    if (cpu_online_map.group_num > HAX_MAX_CPU_GROUP ||
+        cpu_online_map.cpu_num > HAX_MAX_CPUS) {
+        hax_log(HAX_LOGE, "Too many cpus %d-%d in system\n",
+                cpu_online_map.cpu_num, cpu_online_map.group_num);
+        return -E2BIG;
+    }
+
+    cpu_online_map.cpu_map = (hax_cpu_group_t *)hax_vmalloc(size_group, 0);
+    omap.cpu_map = (hax_cpu_group_t *)hax_vmalloc(size_group, 0);
+    if (!cpu_online_map.cpu_map || !omap.cpu_map) {
+        hax_log(HAX_LOGE, "Couldn't allocate cpu_map for cpu_online_map\n");
+        goto fail_nomem;
+    }
+
+    cpu_online_map.cpu_pos = (hax_cpu_pos_t *)hax_vmalloc(size_pos, 0);
+    omap.cpu_pos = (hax_cpu_pos_t *)hax_vmalloc(size_pos, 0);
+    if (!cpu_online_map.cpu_pos || !omap.cpu_pos) {
+        hax_log(HAX_LOGE, "Couldn't allocate cpu_pos for cpu_online_map\n");
+        goto fail_nomem;
+    }
+
+    // omap is filled for get_online_map() to init all host cpu info.
+    // Since smp_cfunction() will check if host cpu is online in cpu_online_map,
+    // but the first call to smp_cfunction() is to init cpu_online_map itself.
+    // Make smp_cfunction() always check group 0 bit 1 for get_online_map(),
+    // so get_online_map() assumes all online and init the real cpu_online_map.
+    omap.group_num = cpu_online_map.group_num;
+    omap.cpu_num = cpu_online_map.cpu_num;
+    for (cpu_id = 0; cpu_id < omap.cpu_num; cpu_id++) {
+        omap.cpu_pos[cpu_id].group = 0;
+        omap.cpu_pos[cpu_id].bit = 0;
+    }
+    for (group = 0; group < omap.group_num; group++) {
+        omap.cpu_map[group].id = 0;
+        omap.cpu_map[group].map = ~0ULL;
+    }
+    hax_smp_call_function(&omap, get_online_map, &cpu_online_map);
+
+    for (group = 0; group < cpu_online_map.group_num; group++) {
+        cpu_online_map.cpu_map[group].num = 0;
+        for (bit = 0; bit < HAX_MAX_CPU_PER_GROUP; bit++) {
+            if (cpu_online_map.cpu_map[group].map & ((hax_cpumask_t)1 << bit))
+                ++cpu_online_map.cpu_map[group].num;
+        }
+    }
+
+    hax_vfree(omap.cpu_map, size_group);
+    hax_vfree(omap.cpu_pos, size_pos);
+
+    hax_log(HAX_LOGI, "Host cpu init %d logical cpu(s) into %d group(s)\n",
+            cpu_online_map.cpu_num, cpu_online_map.group_num);
+
+    return 0;
+
+fail_nomem:
+    if (cpu_online_map.cpu_map)
+        hax_vfree(cpu_online_map.cpu_map, size_group);
+    if (cpu_online_map.cpu_pos)
+        hax_vfree(cpu_online_map.cpu_pos, size_pos);
+    if (omap.cpu_map)
+        hax_vfree(omap.cpu_map, size_group);
+    if (omap.cpu_pos)
+        hax_vfree(omap.cpu_pos, size_pos);
+    return -ENOMEM;
 }
 
 int hax_smp_call_function(hax_cpumap_t *cpus, void (*scfunc)(void *),

--- a/platforms/netbsd/hax_entry_vcpu.c
+++ b/platforms/netbsd/hax_entry_vcpu.c
@@ -67,7 +67,8 @@ int hax_vcpu_open(dev_t self, int flag __unused, int mode __unused,
     struct vcpu_t *cvcpu;
     struct hax_vcpu_netbsd_t *vcpu;
     int ret;
-    int unit, vm_id, vcpu_id;
+    int unit, vm_id;
+    uint32_t vcpu_id;
 
     sc = device_lookup_private(&hax_vcpu_cd, minor(self));
     if (sc == NULL) {

--- a/platforms/netbsd/hax_wrapper.c
+++ b/platforms/netbsd/hax_wrapper.c
@@ -44,9 +44,6 @@
 #include "../../core/include/hax_core_interface.h"
 #include "../../core/include/ia32.h"
 
-int max_cpus;
-hax_cpumap_t cpu_online_map;
-
 static const char* kLogPrefix[] = {
     "haxm: ",
     "haxm_debug: ",
@@ -76,27 +73,96 @@ void hax_panic(const char *fmt,  ...)
     va_end(args);
 }
 
-uint32_t hax_cpuid(void)
+inline uint32_t hax_cpu_id(void)
 {
-    return cpu_index(curcpu());
+    return (uint32_t)cpu_number();
 }
 
-typedef struct smp_call_parameter {
-    void (*func)(void *);
-    void *param;
-    hax_cpumap_t *cpus;
-} smp_call_parameter;
-
-static void smp_cfunction(void *a1, void *a2 __unused)
+int cpu_info_init(void)
 {
-    struct smp_call_parameter *info = a1;
-    hax_cpumap_t *cpus;
-    uint32_t cpuid;
+    struct cpu_info *ci = NULL;
+    CPU_INFO_ITERATOR cii;
+    uint32_t size_group, size_pos, cpu_id, group, bit;
+    hax_cpumap_t omap = {0};
 
-    cpus = info->cpus;
-    cpuid = hax_cpuid();
-    if (*cpus & (0x1 << cpuid))
-        info->func(info->param);
+    memset(&cpu_online_map, 0, sizeof(cpu_online_map));
+
+    cpu_online_map.cpu_num = 0;
+    for (CPU_INFO_FOREACH(cii, ci)) {
+        if (!ISSET(ci->ci_schedstate.spc_flags, SPCF_OFFLINE)) {
+            ++cpu_online_map.cpu_num;
+        }
+    }
+
+    group = HAX_MAX_CPU_PER_GROUP;
+    cpu_online_map.group_num = (cpu_online_map.cpu_num + group - 1) / group;
+    size_group = cpu_online_map.group_num * sizeof(*cpu_online_map.cpu_map);
+    size_pos = cpu_online_map.cpu_num * sizeof(*cpu_online_map.cpu_pos);
+
+    if (cpu_online_map.group_num > HAX_MAX_CPU_GROUP ||
+        cpu_online_map.cpu_num > HAX_MAX_CPUS) {
+        hax_log(HAX_LOGE, "Too many cpus %d-%d in system\n",
+                cpu_online_map.cpu_num, cpu_online_map.group_num);
+        return -E2BIG;
+    }
+
+    cpu_online_map.cpu_map = (hax_cpu_group_t *)hax_vmalloc(size_group, 0);
+    omap.cpu_map = (hax_cpu_group_t *)hax_vmalloc(size_group, 0);
+    if (!cpu_online_map.cpu_map || !omap.cpu_map) {
+        hax_log(HAX_LOGE, "Couldn't allocate cpu_map for cpu_online_map\n");
+        goto fail_nomem;
+    }
+
+    cpu_online_map.cpu_pos = (hax_cpu_pos_t *)hax_vmalloc(size_pos, 0);
+    omap.cpu_pos = (hax_cpu_pos_t *)hax_vmalloc(size_pos, 0);
+    if (!cpu_online_map.cpu_pos || !omap.cpu_pos) {
+        hax_log(HAX_LOGE, "Couldn't allocate cpu_pos for cpu_online_map\n");
+        goto fail_nomem;
+    }
+
+    // omap is filled for get_online_map() to init all host cpu info.
+    // Since smp_cfunction() will check if host cpu is online in cpu_online_map,
+    // but the first call to smp_cfunction() is to init cpu_online_map itself.
+    // Make smp_cfunction() always check group 0 bit 1 for get_online_map(),
+    // so get_online_map() assumes all online and init the real cpu_online_map.
+    omap.group_num = cpu_online_map.group_num;
+    omap.cpu_num = cpu_online_map.cpu_num;
+    for (cpu_id = 0; cpu_id < omap.cpu_num; cpu_id++) {
+        omap.cpu_pos[cpu_id].group = 0;
+        omap.cpu_pos[cpu_id].bit = 0;
+    }
+    for (group = 0; group < omap.group_num; group++) {
+        omap.cpu_map[group].id = 0;
+        omap.cpu_map[group].map = ~0ULL;
+    }
+    hax_smp_call_function(&omap, get_online_map, &cpu_online_map);
+
+    for (group = 0; group < cpu_online_map.group_num; group++) {
+        cpu_online_map.cpu_map[group].num = 0;
+        for (bit = 0; bit < HAX_MAX_CPU_PER_GROUP; bit++) {
+            if (cpu_online_map.cpu_map[group].map & ((hax_cpumask_t)1 << bit))
+                ++cpu_online_map.cpu_map[group].num;
+        }
+    }
+
+    hax_vfree(omap.cpu_map, size_group);
+    hax_vfree(omap.cpu_pos, size_pos);
+
+    hax_log(HAX_LOGI, "Host cpu init %d logical cpu(s) into %d group(s)\n",
+            cpu_online_map.cpu_num, cpu_online_map.group_num);
+
+    return 0;
+
+fail_nomem:
+    if (cpu_online_map.cpu_map)
+        hax_vfree(cpu_online_map.cpu_map, size_group);
+    if (cpu_online_map.cpu_pos)
+        hax_vfree(cpu_online_map.cpu_pos, size_pos);
+    if (omap.cpu_map)
+        hax_vfree(omap.cpu_map, size_group);
+    if (omap.cpu_pos)
+        hax_vfree(omap.cpu_pos, size_pos);
+    return -ENOMEM;
 }
 
 int hax_smp_call_function(hax_cpumap_t *cpus, void (*scfunc)(void *),
@@ -108,7 +174,7 @@ int hax_smp_call_function(hax_cpumap_t *cpus, void (*scfunc)(void *),
     info.func = scfunc;
     info.param = param;
     info.cpus = cpus;
-    xc = xc_broadcast(XC_HIGHPRI, smp_cfunction, &info, NULL);
+    xc = xc_broadcast(XC_HIGHPRI, (xcfunc_t)smp_cfunction, &info, NULL);
     xc_wait(xc);
     return 0;
 }

--- a/platforms/windows/hax_entry.c
+++ b/platforms/windows/hax_entry.c
@@ -54,24 +54,25 @@ DRIVER_UNLOAD HaxUnloadDriver;
 
 static int hax_host_init(void)
 {
-    int i, ret;
-    cpu_online_map = KeQueryActiveProcessors();
+    int ret;
 
-    for (i = 0; i < (sizeof(ULONG_PTR) * 8); i++)
-        if (cpu_online_map & ((mword)0x1 << i))
-            max_cpus = i;
-
-    /* we get the max_cpus from real_cpus in darwin, so add 1 here */
-    max_cpus++;
+    ret = cpu_info_init();
+    if (ret < 0) {
+        hax_log(HAX_LOGE, "CPU info init failed\n");
+        return ret;
+    }
 
     ret = smpc_dpc_init();
     if (ret < 0) {
+        hax_log(HAX_LOGE, "SMPC DPC init failed\n");
+        cpu_info_exit();
         return ret;
     }
 
     if (hax_module_init() < 0) {
             hax_log(HAX_LOGE, "Hax module init failed\n");
             smpc_dpc_exit();
+            cpu_info_exit();
             return -1;
     }
 


### PR DESCRIPTION
Although this patch changed lots of files but only do one thing: make
HAXM run on system with more than 64 logical CPUs.

Previously, HAX_MAX_CPUS is defined as 64, and HAXM stores CPU online
bitmap in 64-bit variable. When running on a system with more than 64
logical CPUs, IPI call actually executed on all CPUs, although internally
HAXM only maintains a 64-bit bitmap. So some per-CPU routine actually
runs on different CPUs, but the 64 loop will check the same pair of
VMXON/VMXOFF for VMX operations, then leads to the error.
Simply increasing the 64-bit bitmap to larger size may resolve the issue
but not efficient and clean.
Previous implementation also has another issue that it invokes
KeQueryActiveProcessors() to get the total logical CPU number, and
KeGetCurrentProcessorNumber() to get the current logical CPU ID. However,
both APIs are NOT designed to get information on Windows with more than
1 CPU groups. Otherwise, both APIs only return value from group 0, which
can't reveal the actual logical CPU information. Instead, user should use
KeQueryActiveProcessorCountEx() and KeGetCurrentProcessorNumberEx().

This patch defines the CPU bitmap in 2-dimention way, in unit of group,
each group can hold up to 64 CPUs for bitmap, same as old implementation.
And introduce another array to store the per-CPU group/bitmap information
so that indexing could be fast. This patch also unify cpu init routines,
more common implementation into same header/source instead of OS specific,
like cpu_info_init(), smp_cfunction(), smp_call_parameter{}, etc. Since
they are very fundamental functions, several files are modified.

Change summary:
- Define 2-dimention structure hax_cpumap_t to store CPU bitmap info.
Including total group number, total logical CPU number, bitmap within
each group, group/bit position for each CPU id.
- For Windows/Linux/Darwin/BSD, use simliar routine cpu_info_init()
to initialize host CPUs, and implement in OS specific way.
- On Windows, use KeQueryActiveProcessorCountEx(),
KeGetCurrentProcessorNumberEx() and KeQueryActiveGroupCount() to get
correct logical CPUs number and group information, and fill hax_cpumap_t.
- For Linux/Darwin/BSD, use OS specific routine to get the total logical
CPU number, and fill into groups consecutive. This is different against
Windows since logical process group is Windows definition, and CPU bitmap
is not guaranteed to consecutively fit into a 64-bit bitmap: 64 logical
CPUs could be in two groups.
- Implement the new cpu_is_online() function with the new hax_cpumap_t.
- Implement the new cpu2cpumap() function with the new hax_cpumap_t.
- Unify OS specific smp_cfunction() implementations in to one, since
the function is executed by IPI on each CPU, check the CPU online with
the new cpu_is_online().
- For all functions refer to the CPU bitmap, use the new implementation.
- For all per-CPU IPI function, add current CPU id in log.

After this patch, HAXM design won't block running on system with a large
number CPUs, and easy to expand in case limitted by the date type range:
now the upper bound is 65536*64 regardless of other resource limitation.

Signed-off-by: Colin Xu <colin.xu@intel.com>