### PR TITLE
Separate old EPT implementation with CONFIG_HAX_EPT2.

### DIFF
--- a/core/ept.c
+++ b/core/ept.c
@@ -240,6 +240,7 @@ static eptp_t ept_construct_eptp(hax_paddr_t addr)
     return eptp;
 }
 
+#ifndef CONFIG_HAX_EPT2
 bool ept_init(hax_vm_t *hax_vm)
 {
     uint i;
@@ -321,6 +322,7 @@ void ept_free (hax_vm_t *hax_vm)
     hax_vfree(hax_vm->ept, sizeof(struct hax_ept));
     hax_vm->ept = 0;
 }
+#endif
 
 struct invept_bundle {
     uint type;

--- a/core/include/ept.h
+++ b/core/include/ept.h
@@ -198,8 +198,10 @@ static void construct_eptp(eptp_t *entry, hax_paddr_t hpa, uint emt)
 #define EPT_INVEPT_SINGLE_CONTEXT 1
 #define EPT_INVEPT_ALL_CONTEXT    2
 
+#ifndef CONFIG_HAX_EPT2
 bool ept_init(hax_vm_t *hax_vm);
 void ept_free(hax_vm_t *hax_vm);
+#endif
 
 uint64_t vcpu_get_eptp(struct vcpu_t *vcpu);
 bool ept_set_pte(hax_vm_t *hax_vm, hax_paddr_t gpa, hax_paddr_t hpa, uint emt,

--- a/core/vm.c
+++ b/core/vm.c
@@ -181,7 +181,9 @@ struct vm_t * hax_create_vm(int *vm_id)
 fail2:
     hax_mutex_free(hvm->vm_lock);
 fail1:
+#ifndef CONFIG_HAX_EPT2
     ept_free(hvm);
+#endif
 fail0:
 #ifdef HAX_ARCH_X86_32
     hax_vfree(hvm->hva_list_1,


### PR DESCRIPTION
Some fail cases in hax_create_vm() may call old EPT implementation,
which are not expected.
Separate old/new EPT routines with CONFIG_HAX_EPT2 so that only one
approarch is enabled at same time.

Signed-off-by: Colin Xu <colin.xu@intel.com>