### PR TITLE
Fix the potential secure issues from static code scan

### DIFF
--- a/platforms/darwin/hax_mem_alloc.cpp
+++ b/platforms/darwin/hax_mem_alloc.cpp
@@ -58,14 +58,18 @@ extern "C" void * hax_vmalloc(uint32_t size, uint32_t flags)
     if (size == 0)
         return NULL;
 
-    if (flags & HAX_MEM_PAGABLE)
+    if (flags & HAX_MEM_PAGABLE) {
         buf = IOMallocPageable(size, HAX_CACHE_ALIGNMENT);
-
-    if (flags & HAX_MEM_NONPAGE)
+    } else if (flags & HAX_MEM_NONPAGE) {
         buf = IOMalloc(size);
+    } else {
+        return NULL;
+    }
 
-    if (buf)
-        memset(buf, 0, size);
+    if (buf == NULL)
+        return NULL;
+
+    memset(buf, 0, size);
 
     return buf;
 }
@@ -76,14 +80,18 @@ extern "C" void * hax_vmalloc_aligned(uint32_t size, uint32_t flags,
     void *buf = NULL;
     HAX_ALLOC_CHECK
 
-    if (flags & HAX_MEM_PAGABLE)
+    if (flags & HAX_MEM_PAGABLE) {
         buf = IOMallocPageable(size, alignment);
-
-    if (flags & HAX_MEM_NONPAGE)
+    } else if (flags & HAX_MEM_NONPAGE) {
         buf = IOMallocAligned(size, alignment);
+    } else {
+        return NULL;
+    }
 
-    if (buf)
-        memset(buf, 0, size);
+    if (buf == NULL)
+        return NULL;
+
+    memset(buf, 0, size);
 
     return buf;
 }

--- a/platforms/windows/hax_host_mem.c
+++ b/platforms/windows/hax_host_mem.c
@@ -108,11 +108,6 @@ uint64_t hax_get_pfn_user(hax_memdesc_user *memdesc, uint64_t uva_offset)
     }
 
     ppfn = MmGetMdlPfnArray(pmdl);
-    if (NULL == ppfn) {
-        hax_log(HAX_LOGE, "Get MDL pfn array failed. uva_offset: 0x%llx.\n",
-                uva_offset);
-        return INVALID_PFN;
-    }
 
     return (uint64_t)ppfn[uva_offset >> PG_ORDER_4K];
 }
@@ -261,10 +256,7 @@ uint64_t hax_get_pfn_phys(hax_memdesc_phys *memdesc)
     }
 
     pfns = MmGetMdlPfnArray(memdesc->pmdl);
-    if (!pfns) {
-        hax_log(HAX_LOGE, "%s: MmGetMdlPfnArray() failed\n", __func__);
-        return INVALID_PFN;
-    }
+
     return pfns[0];
 }
 

--- a/platforms/windows/hax_mem_alloc.c
+++ b/platforms/windows/hax_mem_alloc.c
@@ -97,7 +97,7 @@ struct hax_page * hax_alloc_pages(int order, uint32_t flags, bool vmap)
 {
     struct hax_page *ppage = NULL;
     PMDL pmdl = NULL;
-    uint64_t length = (1 << order) * PAGE_SIZE;
+    uint64_t length = (1ULL << order) * PAGE_SIZE;
     PHYSICAL_ADDRESS high_addr, low_addr, skip_bytes;
 #ifdef MDL_HAX_PAGE
     ULONG options;

--- a/platforms/windows/hax_mem_alloc.c
+++ b/platforms/windows/hax_mem_alloc.c
@@ -50,14 +50,18 @@ void * hax_vmalloc(uint32_t size, uint32_t flags)
     if (flags == 0)
         flags = HAX_MEM_NONPAGE;
 
-    if (flags & HAX_MEM_PAGABLE)
+    if (flags & HAX_MEM_PAGABLE) {
         buf = ExAllocatePoolWithTag(PagedPool, size, HAX_MEM_TAG);
-
-    if (flags & HAX_MEM_NONPAGE)
+    } else if (flags & HAX_MEM_NONPAGE) {
         buf = ExAllocatePoolWithTag(NonPagedPool, size, HAX_MEM_TAG);
+    } else {
+        return NULL;
+    }
 
-    if (buf)
-        memset(buf, 0, size);
+    if (buf == NULL)
+        return NULL;
+
+    memset(buf, 0, size);
 
     return buf;
 }

--- a/platforms/windows/hax_mm.c
+++ b/platforms/windows/hax_mm.c
@@ -73,12 +73,13 @@ int hax_clear_vcpumem(struct hax_vcpu_mem *mem)
 int hax_valid_uva(uint64_t uva, uint64_t size)
 {
     return 1;
-    try {
-        ProbeForRead(&uva, size, PAGE_SIZE);
-    } except (EXCEPTION_EXECUTE_HANDLER) {
-        return 0;
-    }
-    return 1;
+// FIXME: Is it still available to verify the address?
+//    try {
+//        ProbeForRead(&uva, size, PAGE_SIZE);
+//    } except (EXCEPTION_EXECUTE_HANDLER) {
+//        return 0;
+//    }
+//    return 1;
 }
 
 int hax_setup_vcpumem(struct hax_vcpu_mem *mem, uint64_t uva, uint32_t size,


### PR DESCRIPTION
After the security check of the static code scanning tool Coverity, these security patches are made based on the scan results.