### PR TITLE
cpuid: Optimize CPUID storage structure

### DIFF
--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -34,6 +34,8 @@
 #include "../../include/hax.h"
 #include "../../include/hax_types.h"
 
+#define CPUID_FEATURE_SET_SIZE 2
+
 #define CPUID_REG_EAX 0
 #define CPUID_REG_ECX 1
 #define CPUID_REG_EDX 2
@@ -50,11 +52,8 @@ typedef union cpuid_args_t {
 } cpuid_args_t;
 
 typedef struct hax_cpuid_t {
-    uint64_t features_mask;
-    uint32_t feature_1_ecx;
-    uint32_t feature_1_edx;
-    uint32_t feature_8000_0001_ecx;
-    uint32_t feature_8000_0001_edx;
+    uint64_t         features_mask;
+    hax_cpuid_entry  features[CPUID_FEATURE_SET_SIZE];
 } hax_cpuid_t;
 
 /*
@@ -264,11 +263,7 @@ void cpuid_init_supported_features(void);
 void cpuid_guest_init(hax_cpuid_t *cpuid);
 void cpuid_get_features_mask(hax_cpuid_t *cpuid, uint64_t *features_mask);
 void cpuid_set_features_mask(hax_cpuid_t *cpuid, uint64_t features_mask);
-void cpuid_get_guest_features(hax_cpuid_t *cpuid,
-                              uint32_t *cpuid_1_features_ecx,
-                              uint32_t *cpuid_1_features_edx,
-                              uint32_t *cpuid_8000_0001_features_ecx,
-                              uint32_t *cpuid_8000_0001_features_edx);
+void cpuid_get_guest_features(hax_cpuid_t *cpuid, hax_cpuid_entry *features);
 void cpuid_set_guest_features(hax_cpuid_t *cpuid, hax_cpuid *cpuid_info);
 
 #endif /* HAX_CORE_CPUID_H_ */


### PR DESCRIPTION
Use the array of hax_cpuid_entry to store feature set. This approach is
helpful for the extension of more CPUID features support. It ensures
that the same data structure hax_cpuid_entry is used internally and
externally. When adding a new CPUID feature, it makes the implementation
easy by inserting an entry to the array of kCpuidSet.

Signed-off-by: Wenchao Wang <wenchao.wang@intel.com>