### PR TITLE
Fixed releases url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ to this [code of conduct](CODE_OF_CONDUCT.md).
 [intel-vt]: https://www.intel.com/content/www/us/en/virtualization/virtualization-technology/intel-virtualization-technology.html
 [android-studio]: https://developer.android.com/studio/index.html
 [qemu]: https://www.qemu.org/
-[github-haxm-latest-release]: https://github.com/intel/haxm/releases/latest
+[github-haxm-latest-release]: https://github.com/intel/haxm/releases/
 [github-haxm-issues]: https://github.com/intel/haxm/issues
 [intel-security-email]: mailto:secure@intel.com


### PR DESCRIPTION
The previous url opened a view with only the single latest release, which might be "CheckTool" or "HAXM", depending on the current release schedule. 

The new url brings up a reverse-chronological view of the latest releases, so the same information is available at the same place, but scrolling down will give you more recent releases. On the previous url, you couldn't find downloads for HAXM right now, only CheckTool.

Signed-off-by: Abraham Bence <brahambence@gmail.com>