### PR TITLE
Fix some vulnerability issues of loading DRs and MSRs

### DIFF
--- a/core/emulate.c
+++ b/core/emulate.c
@@ -586,28 +586,48 @@ static void register_add(struct em_context_t *ctxt,
 
 static uint8_t insn_fetch_u8(struct em_context_t *ctxt)
 {
-    uint8_t result = *(uint8_t *)(&ctxt->insn[ctxt->len]);
+    uint8_t result;
+
+    if (ctxt->len >= INSTR_MAX_LEN)
+        return 0;
+
+    result = *(uint8_t *)(&ctxt->insn[ctxt->len]);
     ctxt->len += 1;
     return result;
 }
 
 static uint16_t insn_fetch_u16(struct em_context_t *ctxt)
 {
-    uint16_t result = *(uint16_t *)(&ctxt->insn[ctxt->len]);
+    uint16_t result;
+
+    if (ctxt->len >= INSTR_MAX_LEN)
+        return 0;
+
+    result = *(uint16_t *)(&ctxt->insn[ctxt->len]);
     ctxt->len += 2;
     return result;
 }
 
 static uint32_t insn_fetch_u32(struct em_context_t *ctxt)
 {
-    uint32_t result = *(uint32_t *)(&ctxt->insn[ctxt->len]);
+    uint32_t result;
+
+    if (ctxt->len >= INSTR_MAX_LEN)
+        return 0;
+
+    result = *(uint32_t *)(&ctxt->insn[ctxt->len]);
     ctxt->len += 4;
     return result;
 }
 
 static uint64_t insn_fetch_u64(struct em_context_t *ctxt)
 {
-    uint64_t result = *(uint64_t *)(&ctxt->insn[ctxt->len]);
+    uint64_t result;
+
+    if (ctxt->len >= INSTR_MAX_LEN)
+        return 0;
+
+    result = *(uint64_t *)(&ctxt->insn[ctxt->len]);
     ctxt->len += 8;
     return result;
 }

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -45,6 +45,12 @@ struct vcpu_t;
 struct vcpu_state_t;
 
 #define NR_HMSR 6
+// The number of MSRs to be loaded on VM exits
+// Currently the MSRs list only supports automatic loading of below MSRs, the
+// total count of which is 8.
+// * IA32_PMCx
+// * IA32_PERFEVTSELx
+#define NR_HMSR_AUTOLOAD 8
 
 struct hstate {
     /* ldt is not covered by host vmcs area */
@@ -65,6 +71,7 @@ struct hstate {
     uint64_t fs_base;
     uint64_t hcr2;
     struct vmx_msr hmsr[NR_HMSR];
+    vmx_msr_entry hmsr_autoload[NR_HMSR_AUTOLOAD];
     // IA32_PMCx, since APM v1
     uint64_t apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1

--- a/core/include/emulate.h
+++ b/core/include/emulate.h
@@ -99,6 +99,10 @@ struct em_operand_t;
 /* Emulator interface flags */
 #define EM_OPS_NO_TRANSLATION  (1 << 0)
 
+// Instructions are never longer than 15 bytes:
+//   http://wiki.osdev.org/X86-64_Instruction_Encoding
+#define INSTR_MAX_LEN          15
+
 typedef struct em_vcpu_ops_t {
     uint64_t (*read_gpr)(void *vcpu, uint32_t reg_index);
     void (*write_gpr)(void *vcpu, uint32_t reg_index, uint64_t value);

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -42,9 +42,18 @@
 
 #define NR_GMSR     5
 #define NR_EMT64MSR 6
+// The number of MSRs to be loaded on VM entries
+// Currently the MSRs list only supports automatic loading of below MSRs, the
+// total count of which is 14.
+// * IA32_PMCx
+// * IA32_PERFEVTSELx
+// * IA32_TSC_AUX
+// * all MSRs defined in gmsr_list[]
+#define NR_GMSR_AUTOLOAD 14
 
 struct gstate {
     struct vmx_msr gmsr[NR_GMSR];
+    vmx_msr_entry gmsr_autoload[NR_GMSR_AUTOLOAD];
     // IA32_PMCx, since APM v1
     uint64_t apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -639,6 +639,12 @@ struct invept_desc {
     uint64_t rsvd;
 };
 
+// Intel SDM Vol. 3C: Table 24-12. Format of an MSR Entry
+typedef struct ALIGNED(16) vmx_msr_entry {
+    uint64_t index;
+    uint64_t data;
+} vmx_msr_entry;
+
 struct vcpu_state_t;
 struct vcpu_t;
 

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -2117,10 +2117,6 @@ static void vcpu_exit_fpu_state(struct vcpu_t *vcpu)
     }
 }
 
-// Instructions are never longer than 15 bytes:
-//   http://wiki.osdev.org/X86-64_Instruction_Encoding
-#define INSTR_MAX_LEN               15
-
 static bool qemu_support_fastmmio(struct vcpu_t *vcpu)
 {
     struct vm_t *vm = vcpu->vm;

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -47,29 +47,31 @@
 #include "include/hax_core_interface.h"
 #include "include/hax_driver.h"
 
+// Explicit type casting is to prevent the upper 32 bits of the array elements
+// from being filled with 1 due to sign extension of the enum type.
 uint64_t gmsr_list[NR_GMSR] = {
-    IA32_STAR,
-    IA32_LSTAR,
-    IA32_CSTAR,
-    IA32_SF_MASK,
-    IA32_KERNEL_GS_BASE
+    (uint32_t)IA32_STAR,
+    (uint32_t)IA32_LSTAR,
+    (uint32_t)IA32_CSTAR,
+    (uint32_t)IA32_SF_MASK,
+    (uint32_t)IA32_KERNEL_GS_BASE
 };
 
 uint64_t hmsr_list[NR_HMSR] = {
-    IA32_EFER,
-    IA32_STAR,
-    IA32_LSTAR,
-    IA32_CSTAR,
-    IA32_SF_MASK,
-    IA32_KERNEL_GS_BASE
+    (uint32_t)IA32_EFER,
+    (uint32_t)IA32_STAR,
+    (uint32_t)IA32_LSTAR,
+    (uint32_t)IA32_CSTAR,
+    (uint32_t)IA32_SF_MASK,
+    (uint32_t)IA32_KERNEL_GS_BASE
 };
 
 uint64_t emt64_msr[NR_EMT64MSR] = {
-    IA32_STAR,
-    IA32_LSTAR,
-    IA32_CSTAR,
-    IA32_SF_MASK,
-    IA32_KERNEL_GS_BASE
+    (uint32_t)IA32_STAR,
+    (uint32_t)IA32_LSTAR,
+    (uint32_t)IA32_CSTAR,
+    (uint32_t)IA32_SF_MASK,
+    (uint32_t)IA32_KERNEL_GS_BASE
 };
 
 static void vcpu_init(struct vcpu_t *vcpu);
@@ -3096,7 +3098,7 @@ static int handle_msr_read(struct vcpu_t *vcpu, uint32_t msr, uint64_t *val)
         case IA32_SF_MASK:
         case IA32_KERNEL_GS_BASE: {
             for (index = 0; index < NR_GMSR; index++) {
-                if ((uint32_t)gstate->gmsr[index].entry == msr) {
+                if (gstate->gmsr[index].entry == msr) {
                     *val = gstate->gmsr[index].value;
                     break;
                 }
@@ -3430,7 +3432,7 @@ static int handle_msr_write(struct vcpu_t *vcpu, uint32_t msr, uint64_t val,
         case IA32_SF_MASK:
         case IA32_KERNEL_GS_BASE: {
             for (index = 0; index < NR_GMSR; index++) {
-                if ((uint32_t)gmsr_list[index] == msr) {
+                if (gmsr_list[index] == msr) {
                     gstate->gmsr[index].value = val;
                     gstate->gmsr[index].entry = msr;
                     break;

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1172,6 +1172,14 @@ static void load_guest_dr(struct vcpu_t *vcpu)
     if (!(is_guest_dr_dirty(vcpu) || is_host_debug_enabled(vcpu)))
         return;
 
+    // Reset DR7 to zero before setting DR0.
+    // Considering if the host has enabled guest debugging, it could trigger
+    // spurious exceptions in the host by setting a kernel address in DR0.
+    // Spurious exceptions encountered in unexpected conditions (such as with
+    // the user GS loaded, though this particular case does not seem to be
+    // triggerable here) can lead to privilege escalation.
+    set_dr7(0);
+
     set_dr0(state->_dr0);
     set_dr1(state->_dr1);
     set_dr2(state->_dr2);


### PR DESCRIPTION
Fix some vulnerability issues of loading DRs and MSRs during VM entries and exits.

- Reset DR7 before setting DR0 when loading guest DRs
- Automatically load guest and host MSRs by using MSR list
- Add more MSRs to pass-through and fix some MSR array initialization issues
- Check if instruction offset is valid before accessing

Signed-off-by: Wenchao Wang <wenchao.wang@intel.com>