### PR TITLE
Fix some minor issues from static code scan

### DIFF
--- a/core/include/paging.h
+++ b/core/include/paging.h
@@ -363,7 +363,7 @@ static inline void pte64_set_global(pte64_t *entry, uint lvl, bool g)
 static inline void pte64_set_ad(pte64_t *entry, uint lvl, bool d)
 {
     hax_assert(is_leaf(lvl));
-    entry->raw |= (d ? 0x60 : 0x20);
+    entry->raw |= (uint64_t)(d ? 0x60 : 0x20);
 }
 
 static inline void pte64_set_accessed(pte64_t *entry, uint lvl)

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -100,7 +100,7 @@ static int exit_invalid_guest_state(struct vcpu_t *vcpu,
 static int exit_ept_misconfiguration(struct vcpu_t *vcpu,
                                      struct hax_tunnel *htun);
 static int exit_ept_violation(struct vcpu_t *vcpu, struct hax_tunnel *htun);
-static int exit_unsupported_instruction(struct vcpu_t *vcpu, 
+static int exit_unsupported_instruction(struct vcpu_t *vcpu,
                                         struct hax_tunnel *htun);
 static int null_handler(struct vcpu_t *vcpu, struct hax_tunnel *hun);
 
@@ -2884,7 +2884,7 @@ static int exit_dr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
 
             hax_log(HAX_LOGD, "Ignore guest DR%d read due to hw bp enabled.\n",
                     dreg);
-        } else {
+        } else if (dr != NULL) {
             state->_regs[gpr_reg] = *dr;
         }
     } else {
@@ -2892,7 +2892,7 @@ static int exit_dr_access(struct vcpu_t *vcpu, struct hax_tunnel *htun)
         if (hbreak_enabled) {
             hax_log(HAX_LOGD, "Ignore guest DR%d write due to hw bp enabled.\n",
                     dreg);
-        } else {
+        } else if (dr != NULL) {
             *dr = state->_regs[gpr_reg];
             vcpu->dr_dirty = 1;
         }
@@ -3675,7 +3675,7 @@ static int exit_ept_violation(struct vcpu_t *vcpu, struct hax_tunnel *htun)
     return vcpu_emulate_insn(vcpu);
 }
 
-static int exit_unsupported_instruction(struct vcpu_t *vcpu, 
+static int exit_unsupported_instruction(struct vcpu_t *vcpu,
                                         struct hax_tunnel *htun)
 {
     hax_inject_exception(vcpu, VECTOR_UD, NO_ERROR_CODE);

--- a/core/vmx.c
+++ b/core/vmx.c
@@ -216,7 +216,7 @@ uint64_t vmread(struct vcpu_t *vcpu, component_index_t component)
 
 uint64_t vmread_dump(struct vcpu_t *vcpu, unsigned enc, const char *name)
 {
-    uint64_t val;
+    uint64_t val = 0;
 
     switch ((enc >> 13) & 0x3) {
         case 0:


### PR DESCRIPTION
Adjust the code according to the analysis result of Klocwork and fix
some coding style issues.

* Type cast the instant value so that operands in a bitwise operation
  have the same size;
* Judge whether the pointer variable is NULL before accessing it;
* Initialize the variable to prevent returning it directly;
* Trim trailing spaces.

Signed-off-by: Wenchao Wang <wenchao.wang@intel.com>