### PR TITLE
Enable all CPUIDs to be configurable

### DIFF
--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -3962,7 +3962,7 @@ int vcpu_set_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val)
 
 int vcpu_set_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info)
 {
-    hax_log(HAX_LOGI, "%s: vCPU #%u is setting guest CPUID.\n", __func__,
+    hax_log(HAX_LOGW, "%s: vCPU #%u is setting guest CPUID.\n", __func__,
             vcpu->vcpu_id);
 
     if (cpuid_info->total == 0 || cpuid_info->total > HAX_MAX_CPUID_ENTRIES) {

--- a/include/linux/hax_linux.h
+++ b/include/linux/hax_linux.h
@@ -34,6 +34,9 @@
 
 #define HAX_RAM_ENTRY_SIZE 0x4000000
 
+#define min(a,b)  (((a)<(b))?(a):(b))
+#define max(a,b)  (((a)>(b))?(a):(b))
+
 hax_spinlock *hax_spinlock_alloc_init(void);
 void hax_spinlock_free(hax_spinlock *lock);
 void hax_spin_lock(hax_spinlock *lock);


### PR DESCRIPTION
Open all supported CPUID leaves for user space as configurable.
Implement the set_leaf() callback functions for all supported CPUID leaves in the CPUID controller. These setting functions are mainly used for the validity processing of the setting values. When the setting function is NULL, the input value will be completely accepted.