### PR TITLE
Create HAX device securely

### DIFF
--- a/core/cpuid.c
+++ b/core/cpuid.c
@@ -669,6 +669,9 @@ static void execute_0000_000a(cpuid_args_t *args)
 
 static void execute_4000_0000(cpuid_args_t *args)
 {
+    static const char kSignature[13] = "HAXMHAXMHAXM";
+    const uint32_t *kVendorId = (const uint32_t *)kSignature;
+
     if (args == NULL)
         return;
 
@@ -680,8 +683,6 @@ static void execute_4000_0000(cpuid_args_t *args)
     // guest VMM on top of another VMM such as KVM or Hyper-V, in which case
     // EBX, ECX and EDX represent the underlying VMM's vendor ID and should be
     // overridden.
-    static const char kSignature[13] = "HAXMHAXMHAXM";
-    const uint32_t *kVendorId = (const uint32_t *)kSignature;
     // Some VMMs use EAX to indicate the maximum CPUID leaf valid for the range
     // of [0x40000000, 0x4fffffff]
     args->eax = 0x40000000;

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -32,7 +32,7 @@
 #define HAX_CORE_CPUID_H_
 
 #include "../../include/hax.h"
-#include "../../include/hax_types.h"
+#include "types.h"
 
 #define CPUID_REG_EAX 0
 #define CPUID_REG_ECX 1

--- a/core/include/types.h
+++ b/core/include/types.h
@@ -34,4 +34,11 @@
 
 #include "../../include/hax_types.h"
 
+#ifndef min
+#define min(a,b)  (((a)<(b))?(a):(b))
+#endif
+#ifndef max
+#define max(a,b)  (((a)>(b))?(a):(b))
+#endif
+
 #endif  // HAX_CORE_TYPES_H_

--- a/core/memslot.c
+++ b/core/memslot.c
@@ -31,18 +31,12 @@
 #include "../include/hax.h"
 #include "include/memory.h"
 #include "include/paging.h"
+#include "include/types.h"
 
 #define MEMSLOT_PROCESSING 0x01
 #define MEMSLOT_TO_INSERT  0x02
 
 #define SAFE_CALL(f) if ((f) != NULL) (f)
-
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b)) 
-#endif
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b)) 
-#endif
 
 enum callback {
     MAPPING_ADDED = 1,

--- a/include/linux/hax_linux.h
+++ b/include/linux/hax_linux.h
@@ -34,9 +34,6 @@
 
 #define HAX_RAM_ENTRY_SIZE 0x4000000
 
-#define min(a,b)  (((a)<(b))?(a):(b))
-#define max(a,b)  (((a)>(b))?(a):(b))
-
 hax_spinlock *hax_spinlock_alloc_init(void);
 void hax_spinlock_free(hax_spinlock *lock);
 void hax_spin_lock(hax_spinlock *lock);

--- a/platforms/linux/hax_mem_alloc.c
+++ b/platforms/linux/hax_mem_alloc.c
@@ -30,6 +30,7 @@
 
 #include "../../include/hax.h"
 
+#include <asm/io.h>
 #include <linux/mm.h>
 #include <linux/slab.h>
 

--- a/platforms/windows/hax_entry.c
+++ b/platforms/windows/hax_entry.c
@@ -33,6 +33,7 @@
 //#include <ntddk.h>
 #include <ntifs.h>
 #include <string.h>
+#include <wdmsec.h>
 
 #include "hax_win.h"
 
@@ -42,6 +43,13 @@ void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug);
 
 #define NT_DEVICE_NAME L"\\Device\\HAX"
 #define DOS_DEVICE_NAME L"\\DosDevices\\HAX"
+// SDDL string for HAX device object
+// [Access]              [SID]
+// All                   System
+// All                   Administrators
+// Read/Write/Execute    Authenticated Users
+#define SDDL_DEVOBJ_SYS_ALL_ADM_ALL_AU_RWX \
+        L"D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGWGX;;;AU)"
 
 DRIVER_INITIALIZE DriverEntry;
 __drv_dispatchType(IRP_MJ_CREATE)
@@ -96,20 +104,25 @@ NTSTATUS DriverEntry(__in PDRIVER_OBJECT DriverObject,
     int ret;
     UNICODE_STRING  ntUnicodeString;    // NT Device Name "\Device\HAXDEV"
     UNICODE_STRING  ntWin32NameString;
+    UNICODE_STRING  sddlString;
     PDEVICE_OBJECT pDevObj;
     struct hax_dev_ext *DevExt = NULL;
     UNREFERENCED_PARAMETER(RegistryPath);
     RtlInitUnicodeString( &ntUnicodeString, NT_DEVICE_NAME );
     RtlInitUnicodeString( &ntWin32NameString, DOS_DEVICE_NAME );
-    ntStatus = IoCreateDevice(DriverObject,   // Our Driver Object
-                              sizeof(struct hax_dev_ext),
-                              // Device name "\Device\SIOCTL"
-                              &ntUnicodeString,
-                              FILE_DEVICE_UNKNOWN,  // Device type
-                              // Device characteristics
-                              FILE_DEVICE_SECURE_OPEN,
-                              FALSE,  // Not an exclusive device
-                              &pDevObj);  // Returned ptr to Device Object
+    RtlInitUnicodeString( &sddlString, SDDL_DEVOBJ_SYS_ALL_ADM_ALL_AU_RWX );
+
+    ntStatus = IoCreateDeviceSecure(
+            DriverObject,                // HAX driver object
+            sizeof(struct hax_dev_ext),  // Device extension size
+            &ntUnicodeString,            // Device name "\Device\HAX"
+            FILE_DEVICE_UNKNOWN,         // Device type
+            FILE_DEVICE_SECURE_OPEN,     // Device characteristics
+            FALSE,                       // Not an exclusive device
+            &sddlString,                 // SDDL string specifying access
+            NULL,                        // Device class GUID
+            &pDevObj);                   // Returned device object pointer
+
     if (!NT_SUCCESS(ntStatus)) {
         hax_log(HAX_LOGE, "Couldn't create the device object\n");
         write_event(HaxDriverCreateUpDevFailure, DriverObject, NULL, 0);


### PR DESCRIPTION
Create HAX device with the secure function to strengthen the security
level of access.

* Replace the device object creation function by IoCreateDeviceSecure()
* Restrict the maximum scope of the default security settings of the
  device object to authenticated users can read, write and execute

Signed-off-by: Wenchao Wang <wenchao.wang@intel.com>