### PR TITLE
Load all host MSRs manually

### DIFF
--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -45,12 +45,6 @@ struct vcpu_t;
 struct vcpu_state_t;
 
 #define NR_HMSR 6
-// The number of MSRs to be loaded on VM exits
-// Currently the MSRs list only supports automatic loading of below MSRs, the
-// total count of which is 8.
-// * IA32_PMCx
-// * IA32_PERFEVTSELx
-#define NR_HMSR_AUTOLOAD 8
 
 struct hstate {
     /* ldt is not covered by host vmcs area */
@@ -71,7 +65,6 @@ struct hstate {
     uint64_t fs_base;
     uint64_t hcr2;
     struct vmx_msr hmsr[NR_HMSR];
-    vmx_msr_entry hmsr_autoload[NR_HMSR_AUTOLOAD];
     // IA32_PMCx, since APM v1
     uint64_t apm_pmc_msrs[APM_MAX_GENERAL_COUNT];
     // IA32_PERFEVTSELx, since APM v1


### PR DESCRIPTION
Restore manually loading below MSRs. This is a regression caused by f800982.

* IA32_PMC0 .. IA32_PMC3
* IA32_PERFEVTSEL0 .. IA32_PERFEVTSEL3