### PR TITLE
Improve CPUID module

### DIFF
--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -261,6 +261,7 @@ bool cpuid_host_has_feature_uncached(uint32_t feature_key);
 void cpuid_init_supported_features(void);
 uint32_t cpuid_guest_get_size(void);
 void cpuid_guest_init(hax_cpuid_t *cpuid);
+bool cpuid_guest_has_feature(hax_cpuid_t *cpuid, uint32_t feature_key);
 void cpuid_execute(hax_cpuid_t *cpuid, cpuid_args_t *args);
 void cpuid_get_features_mask(hax_cpuid_t *cpuid, uint64_t *features_mask);
 void cpuid_set_features_mask(hax_cpuid_t *cpuid, uint64_t features_mask);

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -203,6 +203,7 @@ enum {
     X86_FEATURE_AVX2          = FEAT(5),  /* 0x00000020  Advanced Vector Extensions 2 */
     X86_FEATURE_SMEP          = FEAT(7),  /* 0x00000080  Supervisor-Mode Execution Prevention */
     X86_FEATURE_BMI2          = FEAT(8),  /* 0x00000100  Bit Manipulation Instruction Set 2 */
+    X86_FEATURE_ERMS          = FEAT(9),  /* 0x00000200  Enhanced REP MOVSB/STOSB */
     X86_FEATURE_INVPCID       = FEAT(10), /* 0x00000400  INVPCID instruction */
     X86_FEATURE_RTM           = FEAT(11), /* 0x00000800  Transactional Synchronization Extensions */
     X86_FEATURE_RDT_M         = FEAT(12), /* 0x00001000  Resource Director Technology Monitoring */


### PR DESCRIPTION
Improve the implementation of CPUID module

* Add sub-leaf to extend support for more features
* Add elementary operations for specified x86 feature bit in guest CPUID, including checking, setting and clearing, as well as implement some reverse parse functions for the feature key
* Adjust the implementation for CPUID.07H