### PR TITLE
Enable INVPCID instruction

### DIFF
--- a/core/cpuid.c
+++ b/core/cpuid.c
@@ -330,7 +330,8 @@ void cpuid_init_supported_features(void)
         .function = 0x07,
         .index = 0,
         .ebx =
-            FEATURE(ERMS)
+            FEATURE(ERMS)       |
+            FEATURE(INVPCID)
     };
     hax_supported[2] = (hax_cpuid_entry){
         .function = 0x80000001,

--- a/core/include/vmx.h
+++ b/core/include/vmx.h
@@ -297,7 +297,8 @@ typedef enum component_index_t component_index_t;
 #define WBINVD_EXITING                         0x00000040
 #define UNRESTRICTED_GUEST                     0x00000080
 #define PAUSE_LOOP_EXITING                     0x00000400
-#define SECONDARY_CONTROLS_DEFINED             0x000004ff
+#define ENABLE_INVPCID                         0x00001000
+#define SECONDARY_CONTROLS_DEFINED             0x000014ff
 
 // Exit Controls
 #define EXIT_CONTROL_SAVE_DEBUG_CONTROLS       0x00000004

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -1428,6 +1428,13 @@ static void fill_common_vmcs(struct vcpu_t *vcpu)
         }
     }
 
+    // Make the INVPCID instruction available to the guest if the host supports
+    // it (cf. Intel SDM Vol. 3C Table 24-7, bit 12: Enable INVPCID)
+    if (cpu_has_feature(X86_FEATURE_INVPCID)) {
+        // TODO: Check VMX capabilities to ensure ENABLE_INVPCID is available
+        scpu_ctls |= ENABLE_INVPCID;
+    }
+
 #ifdef HAX_ARCH_X86_64
     exit_ctls = EXIT_CONTROL_HOST_ADDR_SPACE_SIZE | EXIT_CONTROL_LOAD_EFER |
                 EXIT_CONTROL_SAVE_DEBUG_CONTROLS | EXIT_CONTROL_LOAD_PAT;


### PR DESCRIPTION
When running a Linux virtual machine on top of hardware that suffers from meltdown vulnerabilities (i.e., the processor does not advertise the "No Rogue Data Cache Load" bit in the IA32_ARCH_CAPABILITIES MSR), the Linux guest will enable "Kernel Page Table Isolation" (aka KPTI).

This has performance impacts because the page tables need to be adjusted on each jump between user mode and kernel mode. The Linux kernel will perform it more efficiently if it has the ability to use the INVPCID instruction.