### PR TITLE
Enable XSAVE feature in CPUID

### DIFF
--- a/core/cpuid.c
+++ b/core/cpuid.c
@@ -31,6 +31,7 @@
 
 #include "cpuid.h"
 
+#include "cpu.h"
 #include "driver.h"
 #include "fpu.h"
 #include "ia32.h"
@@ -562,6 +563,16 @@ int cpuid_set_guest_features(hax_cpuid_t *cpuid, hax_cpuid *cpuid_info)
     dump_features(cpuid->features, CPUID_TOTAL_LEAVES);
 
     return 0;
+}
+
+void cpuid_post_set_features(hax_cpuid_t *cpuid, struct vm_t *vm)
+{
+    hax_cpuid_entry *entry;
+
+    entry = find_cpuid_entry(cpuid->features, CPUID_TOTAL_LEAVES, 0x0d, 0);
+
+    vm->valid_xcr0 = (entry == NULL) ? 0 : (entry->eax |
+            ((uint64_t)entry->edx << 32)) & hax->supported_xcr0;
 }
 
 static uint32_t feature_leaf(uint32_t feature_key)

--- a/core/cpuid.c
+++ b/core/cpuid.c
@@ -315,6 +315,7 @@ void cpuid_init_supported_features(void)
             FEATURE(AESNI)      |
             FEATURE(PCLMULQDQ)  |
             FEATURE(POPCNT)     |
+            FEATURE(XSAVE)      |
             FEATURE(AVX)        |
             FEATURE(F16C),
         .edx =

--- a/core/ia32.c
+++ b/core/ia32.c
@@ -38,10 +38,14 @@ struct qword_val {
 #ifdef HAX_ARCH_X86_32
 extern void ASMCALL asm_rdmsr(uint32_t reg, struct qword_val *qv);
 extern void ASMCALL asm_wrmsr(uint32_t reg, struct qword_val *qv);
+extern void ASMCALL asm_xgetbv(uint32_t reg, struct qword_val *qv);
+extern void ASMCALL asm_xsetbv(uint32_t reg, struct qword_val *qv);
 extern void ASMCALL asm_rdtsc(struct qword_val *qv);
 #else  // !HAX_ARCH_X86_32
 extern uint64_t ASMCALL asm_rdmsr(uint32_t reg);
 extern void ASMCALL asm_wrmsr(uint32_t reg, uint64_t val);
+extern uint64_t ASMCALL asm_xgetbv(uint32_t reg);
+extern void ASMCALL asm_xsetbv(uint32_t reg, uint64_t val);
 extern uint64_t ASMCALL asm_rdtsc(void);
 #endif  // HAX_ARCH_X86_32
 
@@ -67,6 +71,33 @@ void ia32_wrmsr(uint32_t reg, uint64_t val)
     asm_wrmsr(reg, &tmp);
 #else
     asm_wrmsr(reg, val);
+#endif
+}
+
+uint64_t ia32_xgetbv(uint32_t reg)
+{
+#ifdef HAX_ARCH_X86_32
+    struct qword_val value = {0};
+
+    asm_xgetbv(reg, &value);
+
+    return ((uint64_t)value.low | (uint64_t)value.high << 32);
+#else
+    return asm_xgetbv(reg);
+#endif
+}
+
+void ia32_xsetbv(uint32_t reg, uint64_t val)
+{
+#ifdef HAX_ARCH_X86_32
+    struct qword_val value = {0};
+
+    value.high = (uint32_t)(val >> 32);
+    value.low = (uint32_t)val;
+
+    asm_xsetbv(reg, &value);
+#else
+    asm_xsetbv(reg, val);
 #endif
 }
 

--- a/core/ia32_ops.asm
+++ b/core/ia32_ops.asm
@@ -289,6 +289,48 @@ function asm_wrmsr, 2
     %error "Unimplemented function"
 %endif
 
+function asm_xgetbv, 2
+%ifidn __BITS__, 64
+    mov rcx, reg_arg1
+    xgetbv
+    shl rdx, 32
+    or reg_ret, rdx
+    ret
+%elifidn __CONV__, x32_cdecl
+    push ebx
+    mov ebx, reg_arg2
+    xgetbv
+    mov [ebx + qword_struct.lo], eax
+    mov [ebx + qword_struct.hi], edx
+    pop ebx
+    ret
+%else
+    %error "Unimplemented function"
+%endif
+
+function asm_xsetbv, 2
+%ifidn __BITS__, 64
+    mov rcx, reg_arg1
+    mov rax, reg_arg2
+    mov rdx, reg_arg2
+    shr rdx, 32
+    xsetbv
+    ret
+%elifidn __CONV__, x32_cdecl
+    push edi
+    push esi
+    mov edi, [reg_arg2 + qword_struct.lo]
+    mov esi, [reg_arg2 + qword_struct.hi]
+    mov eax, edi
+    mov edx, esi
+    xsetbv
+    pop esi
+    pop edi
+    ret
+%else
+    %error "Unimplemented function"
+%endif
+
 function get_kernel_tr_selector, 0
     str reg_ret_16
     ret

--- a/core/include/cpu.h
+++ b/core/include/cpu.h
@@ -84,6 +84,8 @@ struct hstate {
     uint64_t dr7;
     // CR0
     bool cr0_ts;
+    // XCR0
+    uint64_t xcr0;
     uint64_t _pat;
 };
 

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -279,6 +279,7 @@ uint32_t cpuid_guest_get_size(void);
 void cpuid_guest_init(hax_cpuid_t *cpuid);
 bool cpuid_guest_has_feature(hax_cpuid_t *cpuid, uint32_t feature_key);
 void cpuid_execute(hax_cpuid_t *cpuid, cpuid_args_t *args);
+void cpuid_update(hax_cpuid_t *cpuid, vcpu_state_t *state);
 void cpuid_get_features_mask(hax_cpuid_t *cpuid, uint64_t *features_mask);
 void cpuid_set_features_mask(hax_cpuid_t *cpuid, uint64_t features_mask);
 int cpuid_get_guest_features(hax_cpuid_t *cpuid, hax_cpuid *cpuid_info);

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -227,11 +227,24 @@ enum {
 
     /*
      * Intel SDM Vol. 2A: Table 3-8. Information Returned by CPUID Instruction
+     * Processor Extended State Enumeration Sub-leaf
+     * Features for CPUID with EAX=0dh, ECX=01h stored in EAX
+     */
+#define FEAT(bit) \
+    FEATURE_KEY_SUBLEAF(4, 0x0d, 0x01, CPUID_REG_EAX, bit)
+    X86_FEATURE_XSAVEOPT      = FEAT(0),  /* 0x00000001  XSAVEOPT instruction */
+    X86_FEATURE_XSAVEC        = FEAT(1),  /* 0x00000002  XSAVEC instruction */
+    X86_FEATURE_XGETBV1       = FEAT(2),  /* 0x00000004  XGETBV with ECX = 1 instruction */
+    X86_FEATURE_XSAVES        = FEAT(3),  /* 0x00000008  XSAVES/XRSTORS instructions */
+#undef FEAT
+
+    /*
+     * Intel SDM Vol. 2A: Table 3-8. Information Returned by CPUID Instruction
      * Extended Function CPUID Information
      * Features for CPUID with EAX=80000001h stored in ECX
      */
 #define FEAT(bit) \
-    FEATURE_KEY_LEAF(4, 0x80000001, CPUID_REG_ECX, bit)
+    FEATURE_KEY_LEAF(5, 0x80000001, CPUID_REG_ECX, bit)
     X86_FEATURE_LAHF          = FEAT(0),  /* 0x00000001  LAHF/SAHF Instructions */
     X86_FEATURE_PREFETCHW     = FEAT(8),  /* 0x00000100  PREFETCH/PREFETCHW instructions */
 #undef FEAT
@@ -242,7 +255,7 @@ enum {
      * Features for CPUID with EAX=80000001h stored in EDX
      */
 #define FEAT(bit) \
-    FEATURE_KEY_LEAF(5, 0x80000001, CPUID_REG_EDX, bit)
+    FEATURE_KEY_LEAF(6, 0x80000001, CPUID_REG_EDX, bit)
     X86_FEATURE_SYSCALL       = FEAT(11), /* 0x00000800  SYSCALL/SYSRET Instructions */
     X86_FEATURE_NX            = FEAT(20), /* 0x00100000  No-Execute Bit */
     X86_FEATURE_PDPE1GB       = FEAT(26), /* 0x04000000  Gibibyte pages */

--- a/core/include/cpuid.h
+++ b/core/include/cpuid.h
@@ -40,6 +40,8 @@
 #define CPUID_REG_EDX 2
 #define CPUID_REG_EBX 3
 
+struct vm_t;
+
 typedef union cpuid_args_t {
     struct {
         uint32_t eax;
@@ -281,5 +283,6 @@ void cpuid_get_features_mask(hax_cpuid_t *cpuid, uint64_t *features_mask);
 void cpuid_set_features_mask(hax_cpuid_t *cpuid, uint64_t features_mask);
 int cpuid_get_guest_features(hax_cpuid_t *cpuid, hax_cpuid *cpuid_info);
 int cpuid_set_guest_features(hax_cpuid_t *cpuid, hax_cpuid *cpuid_info);
+void cpuid_post_set_features(hax_cpuid_t *cpuid, struct vm_t *vm);
 
 #endif /* HAX_CORE_CPUID_H_ */

--- a/core/include/driver.h
+++ b/core/include/driver.h
@@ -52,6 +52,7 @@ struct hax_t {
     uint32_t apm_event_unavailability;
     uint apm_fixed_count;
     uint64_t apm_fixed_mask;
+    uint64_t supported_xcr0;
     // Unparsed CPUID leaf 0xa output for CPUID virtualization
     struct cpu_pmu_info apm_cpuid_0xa;
 

--- a/core/include/fpu.h
+++ b/core/include/fpu.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HAX_CORE_FPU_H_
+#define HAX_CORE_FPU_H_
+
+#include "hax_types.h"
+
+// Intel SDM Vol. 1: 13.1 XSAVE-Supported Features and State-Component Bitmaps
+// XSAVE-supported features
+enum xfeature {
+    // Legacy states
+    XFEATURE_FP,                 // x87 state
+    XFEATURE_SSE,                // SSE state
+    // Extended states
+    XFEATURE_YMM,                // AVX state
+    XFEATURE_BNDREGS,            // MPX state (BNDREGS)
+    XFEATURE_BNDCSR,             // MPX state (BNDCSR)
+    XFEATURE_OPMASK,             // AVX-512 state (opmask)
+    XFEATURE_ZMM_Hi256,          // AVX-512 state (ZMM_Hi256)
+    XFEATURE_Hi16_ZMM,           // AVX-512 state (Hi16_ZMM)
+    XFEATURE_PT,                 // PT state
+    XFEATURE_PKRU,               // PKRU state
+    XFEATURE_PASID,              // PASID state
+    XFEATURE_CET_U,              // CET state (CET_U)
+    XFEATURE_CET_S,              // CET state (CET_S)
+    XFEATURE_HDC,                // HDC state
+    XFEATURE_RESERVED,           // Reserved
+    XFEATURE_LBR,                // LBR state
+    XFEATURE_HWP,                // HWP state
+    // State maximum
+    XFEATURE_MAX
+};
+
+// State-component bitmaps
+#define XFEATURE_MASK_FP         (1 << XFEATURE_FP)
+#define XFEATURE_MASK_SSE        (1 << XFEATURE_SSE)
+#define XFEATURE_MASK_YMM        (1 << XFEATURE_YMM)
+#define XFEATURE_MASK_BNDREGS    (1 << XFEATURE_BNDREGS)
+#define XFEATURE_MASK_BNDCSR     (1 << XFEATURE_BNDCSR)
+#define XFEATURE_MASK_OPMASK     (1 << XFEATURE_OPMASK)
+#define XFEATURE_MASK_ZMM_Hi256  (1 << XFEATURE_ZMM_Hi256)
+#define XFEATURE_MASK_Hi16_ZMM   (1 << XFEATURE_Hi16_ZMM)
+#define XFEATURE_MASK_PT         (1 << XFEATURE_PT)
+#define XFEATURE_MASK_PKRU       (1 << XFEATURE_PKRU)
+#define XFEATURE_MASK_PASID      (1 << XFEATURE_PASID)
+#define XFEATURE_MASK_CET_U      (1 << XFEATURE_CET_U)
+#define XFEATURE_MASK_CET_S      (1 << XFEATURE_CET_S)
+#define XFEATURE_MASK_HDC        (1 << XFEATURE_HDC)
+#define XFEATURE_MASK_LBR        (1 << XFEATURE_LBR)
+#define XFEATURE_MASK_HWP        (1 << XFEATURE_HWP)
+
+#define XFEATURE_MASK_LEGACY     (XFEATURE_MASK_FP | XFEATURE_MASK_SSE)
+#define XFEATURE_MASK_AVX512     (XFEATURE_MASK_OPMASK    | \
+                                  XFEATURE_MASK_ZMM_Hi256 | \
+                                  XFEATURE_MASK_Hi16_ZMM)
+// Bit 63 is used for special functionality in some bitmaps and does not
+// correspond to any state component.
+#define XFEATURE_MASK_EXTENDED   (~(XFEATURE_MASK_LEGACY | (1ULL << 63)))
+
+// XCR
+#define HAX_SUPPORTED_XCR0       (XFEATURE_MASK_FP | XFEATURE_MASK_SSE | \
+                                  XFEATURE_MASK_YMM)
+
+#define XCR_XFEATURE_ENABLED_MASK  0x00000000
+
+#endif  // HAX_CORE_FPU_H_

--- a/core/include/fpu.h
+++ b/core/include/fpu.h
@@ -91,4 +91,10 @@ enum xfeature {
 
 #define XCR_XFEATURE_ENABLED_MASK  0x00000000
 
+// XSTATE
+#define FXSAVE_SIZE              512
+
+#define XSAVE_HDR_SIZE           64
+#define XSAVE_HDR_OFFSET         FXSAVE_SIZE
+
 #endif  // HAX_CORE_FPU_H_

--- a/core/include/ia32.h
+++ b/core/include/ia32.h
@@ -83,6 +83,8 @@ uint32_t ASMCALL asm_fls(uint32_t bit32);
 
 uint64_t ia32_rdmsr(uint32_t reg);
 void ia32_wrmsr(uint32_t reg, uint64_t val);
+uint64_t ia32_xgetbv(uint32_t reg);
+void ia32_xsetbv(uint32_t reg, uint64_t val);
 
 uint64_t ia32_rdtsc(void);
 

--- a/core/include/ia32_defs.h
+++ b/core/include/ia32_defs.h
@@ -33,8 +33,6 @@
 
 #include "types.h"
 
-#define IA32_FXSAVE_SIZE 512
-
 enum {
     CR0_PE          = (1  <<  0),
     CR0_MP          = (1  <<  1),

--- a/core/include/ia32_defs.h
+++ b/core/include/ia32_defs.h
@@ -50,19 +50,30 @@ enum {
 };
 
 enum {
-    CR4_VME         = (1 <<  0),
-    CR4_PVI         = (1 <<  1),
-    CR4_TSD         = (1 <<  2),
-    CR4_DE          = (1 <<  3),
-    CR4_PSE         = (1 <<  4),
-    CR4_PAE         = (1 <<  5),
-    CR4_MCE         = (1 <<  6),
-    CR4_PGE         = (1 <<  7),
-    CR4_PCE         = (1 <<  8),
-    CR4_OSFXSR      = (1 <<  9),
-    CR4_OSXMMEXCPT  = (1 << 10),
-    CR4_VMXE        = (1 << 13),
-    CR4_SMXE        = (1 << 14)
+    CR4_VME         = (1 <<  0),  // Enables virtual-8086 mode extensions
+    CR4_PVI         = (1 <<  1),  // Enables protected-mode virtual interrupts
+    CR4_TSD         = (1 <<  2),  // Time stamp disable (CPL > 0)
+    CR4_DE          = (1 <<  3),  // Enables debugging extensions
+    CR4_PSE         = (1 <<  4),  // Enables page size extensions
+    CR4_PAE         = (1 <<  5),  // Enables physical address extensions
+    CR4_MCE         = (1 <<  6),  // Machine-check enable
+    CR4_PGE         = (1 <<  7),  // Page global enable
+    CR4_PCE         = (1 <<  8),  // Performance-monitoring counter enable
+    CR4_OSFXSR      = (1 <<  9),  // Enables OS support for FXSAVE and FXRSTOR
+    CR4_OSXMMEXCPT  = (1 << 10),  // Enables unmasked SSE exceptions
+    CR4_UMIP        = (1 << 11),  // Enables user-mode instruction prevention
+    CR4_LA57        = (1 << 12),  // Enables 57-bit linear addresses
+    CR4_VMXE        = (1 << 13),  // Virtual machine extensions enable bit
+    CR4_SMXE        = (1 << 14),  // Safer mode extensions enable bit
+    CR4_FSGSBASE    = (1 << 16),  // Enables FSGSBASE instructions
+    CR4_PCIDE       = (1 << 17),  // Process-context identifiers enable bit
+    CR4_OSXSAVE     = (1 << 18),  // Enables XSAVE and processor extended states
+    CR4_KL          = (1 << 19),  // Enables key locker
+    CR4_SMEP        = (1 << 20),  // Enables SMEP
+    CR4_SMAP        = (1 << 21),  // Enables SMAP
+    CR4_PKE         = (1 << 22),  // Enables protection keys
+    CR4_CET         = (1 << 23),  // Enables control-flow enforcement technology
+    CR4_PKS         = (1 << 24)   // Enables protection keys (supervisor-mode)
 };
 
 enum {

--- a/core/include/segments.h
+++ b/core/include/segments.h
@@ -40,6 +40,9 @@
 #pragma pack(push, 1)
 #endif
 
+#define AR_DPL_SHIFT 5
+#define AR_DPL(ar) (((ar) >> AR_DPL_SHIFT) & 0x3)
+
 struct seg_desc_t {
     union {
         struct {

--- a/core/include/vcpu.h
+++ b/core/include/vcpu.h
@@ -259,6 +259,8 @@ int vcpu_get_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_put_fpu(struct vcpu_t *vcpu, struct fx_layout *fl);
 int vcpu_get_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t *val);
 int vcpu_put_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val);
+int vcpu_set_xcr(struct vcpu_t *vcpu, uint32_t index, uint64_t value);
+int vcpu_get_xcr(struct vcpu_t *vcpu, uint32_t index, uint64_t *value);
 int vcpu_set_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info);
 int vcpu_get_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info);
 void vcpu_debug(struct vcpu_t *vcpu, struct hax_debug_t *debug);

--- a/core/include/vm.h
+++ b/core/include/vm.h
@@ -65,6 +65,7 @@ struct vm_t {
     hax_list_head hvm_list;
     hax_list_head vcpu_list;
     uint16_t bsp_vcpu_id;
+    uint64_t valid_xcr0;
     void *vm_host;
     void *p2m_map[MAX_GMEM_G];
     hax_gpa_space gpa_space;

--- a/core/vcpu.c
+++ b/core/vcpu.c
@@ -3888,6 +3888,8 @@ int vcpu_set_msr(struct vcpu_t *vcpu, uint64_t entry, uint64_t val)
 
 int vcpu_set_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info)
 {
+    int ret;
+
     hax_log(HAX_LOGW, "%s: vCPU #%u is setting guest CPUID.\n", __func__,
             vcpu->vcpu_id);
 
@@ -3903,7 +3905,10 @@ int vcpu_set_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info)
         return -EFAULT;
     }
 
-    return cpuid_set_guest_features(vcpu->guest_cpuid, cpuid_info);
+    ret = cpuid_set_guest_features(vcpu->guest_cpuid, cpuid_info);
+    cpuid_post_set_features(vcpu->guest_cpuid, vcpu->vm);
+
+    return ret;
 }
 
 int vcpu_get_cpuid(struct vcpu_t *vcpu, hax_cpuid *cpuid_info)
@@ -4271,6 +4276,7 @@ static void vcpu_init_cpuid(struct vcpu_t *vcpu)
     cpuid_guest_init(vcpu->guest_cpuid);
     hax_log(HAX_LOGI, "%s: initialized vcpu[%u].guest_cpuid with default "
             "feature set.\n", __func__, vcpu->vcpu_id);
+    cpuid_post_set_features(vcpu->guest_cpuid, vcpu->vm);
 }
 
 static int vcpu_alloc_cpuid(struct vcpu_t *vcpu)

--- a/include/hax_vcpu_state.h
+++ b/include/hax_vcpu_state.h
@@ -171,6 +171,8 @@ struct vcpu_state_t {
     uint64_t _cr3;
     uint64_t _cr4;
 
+    uint64_t _xcr0;
+
     uint64_t _dr0;
     uint64_t _dr1;
     uint64_t _dr2;
@@ -189,6 +191,8 @@ struct vcpu_state_t {
     uint32_t pad;
     interruptibility_state_t _interruptibility_state;
 } PACKED;
+
+typedef struct vcpu_state_t vcpu_state_t;
 
 void dump(void);
 


### PR DESCRIPTION
The XSAVE feature set extends the functionality of the FXSAVE and FXRSTOR instructions (see Intel SDM Vol. 1: 13 Managing State using the XSAVE Feature Set). Some current features, such as AVX, will only work properly if the XSAVE feature is enabled.

Enabling XSAVE feature allows the guest OS with AVX (or other XSAVE-supported features) enabled can boot normally.